### PR TITLE
fix(message): complete error message when instance is not found

### DIFF
--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -15,7 +15,6 @@ const getInstance = function (context?: Context, selector = '#t-message') {
   }
   const instance = context?.selectComponent(selector);
   if (!instance) {
-    console.warn('未找到Message组件, 请检查selector是否正确');
     return null;
   }
   return instance;
@@ -27,7 +26,10 @@ const showMessage = function (
 ) {
   const { context, selector } = options;
   const instance = getInstance(context, selector);
-  if (!instance) return Promise.reject();
+
+  if (!instance) {
+    return Promise.reject(new Error('未找到Message组件, 请检查selector是否正确'));
+  }
 
   // instance.hide();
 


### PR DESCRIPTION
修复：当 message 组件未引入时，应该使用 `reject` 而不是 `console.warn` 来输出错误信息

close #67 