### PR TITLE
fix(button): large size width error

### DIFF
--- a/src/button/button.less
+++ b/src/button/button.less
@@ -157,6 +157,7 @@
   &.@{prefix}-size {
     &-l {
       display: flex;
+      width: auto;
       margin: 0 32rpx;
       height: @button-large-height;
       line-height: @button-large-height;


### PR DESCRIPTION
当 `"style"="v2"`, 微信小程序会有以下自带样式, 使得按钮 large size 的宽度显示不正常(如无法占满父组件等)

```css
button:not([size=mini]) {
    margin-left: auto;
    margin-right: auto;
    width: 184px;
}
```

通过为 `t-size-l` 设置 `width: auto;` 修复