### PR TITLE
fix(dialog): calc button width correctly

### DIFF
--- a/src/dialog/dialog.less
+++ b/src/dialog/dialog.less
@@ -94,7 +94,7 @@ page {
       border-bottom: 0;
 
       &-half {
-        width: @dialog-width / 2;
+        width: (@dialog-width / 2 );
       }
 
       &-confirm {


### PR DESCRIPTION
Dialog: 修复按钮宽度计算错误的问题