### PR TITLE
fix: stepper使用标题时,cell的slot改为right-icon

### DIFF
--- a/example/pages/stepper/stepper.wxml
+++ b/example/pages/stepper/stepper.wxml
@@ -3,13 +3,13 @@
   <view class="t-stepper-desc">用于数量的增减。</view>
   <t-demo title="01 类型" desc="基本步进器">
     <t-cell title="标题文字">
-      <view class="cell-badge-wrap" slot="note">
+      <view class="cell-badge-wrap" slot="right-icon">
         <t-stepper defaultValue="0" />
       </view>
     </t-cell>
     <view class="t-stepper-wrapper-desc">带单位步进器</view>
     <t-cell title="标题文字（单位）">
-      <view class="cell-badge-wrap" slot="note">
+      <view class="cell-badge-wrap" slot="right-icon">
         <t-stepper defaultValue="0" step="2" />
       </view>
     </t-cell>
@@ -22,25 +22,25 @@
   <t-demo title="02 状态" desc="步进器状态">
     <view class="stepper-content">
       <t-cell title="禁用">
-        <view class="cell-badge-wrap" slot="note">
+        <view class="cell-badge-wrap" slot="right-icon">
           <t-stepper disabled="true" />
         </view>
       </t-cell>
       <view class="interval" />
       <t-cell title="禁用（单位）">
-        <view class="cell-badge-wrap" slot="note">
+        <view class="cell-badge-wrap" slot="right-icon">
           <t-stepper step="2" disabled="true" />
         </view>
       </t-cell>
       <view class="interval" />
       <t-cell title="最小值 (5)">
-        <view class="cell-badge-wrap" slot="note">
+        <view class="cell-badge-wrap" slot="right-icon">
           <t-stepper defaultValue="5" min="5" />
         </view>
       </t-cell>
       <view class="interval" />
       <t-cell title="最大值 (999)">
-        <view class="cell-badge-wrap" slot="note">
+        <view class="cell-badge-wrap" slot="right-icon">
           <t-stepper defaultValue="999" max="999" />
         </view>
       </t-cell>

--- a/src/stepper/README.md
+++ b/src/stepper/README.md
@@ -23,7 +23,7 @@ isComponent: true
 
 ```html
 <t-cell title="标题文字（单位）">
-  <view class="cell-badge-wrap" slot="note">
+  <view class="cell-badge-wrap" slot="right-icon">
     <t-stepper defaultValue="0" step="2" />
   </view>
 </t-cell>


### PR DESCRIPTION
e.g. "fix #166"