### PR TITLE
fix: [toast] API调用，多次调用时，对于后续未传入的参数，会重复使用之前传入的参数值的问题。修改为，对未传入的参数使用默认值。

### DIFF
--- a/example/pages/toast/toast.ts
+++ b/example/pages/toast/toast.ts
@@ -86,12 +86,6 @@ Page({
     Toast({
       context: this,
       selector: '#t-toast',
-      icon: '',
-      theme: '',
-      direction: 'row',
-      placement: 'middle',
-      preventScrollThrough: false,
-      duration: 2000,
       ...option,
     });
   },

--- a/src/toast/toast.ts
+++ b/src/toast/toast.ts
@@ -33,7 +33,17 @@ export default class Toast extends SuperComponent {
 
   properties = Props;
 
-  show(options: TdToastProps) {
+  show(userOptions: TdToastProps) {
+    const options = {
+      message: '',
+      icon: '',
+      theme: '',
+      direction: 'row',
+      placement: 'middle',
+      preventScrollThrough: false,
+      duration: 2000,
+      ...userOptions,
+    };
     if (this.hideTimer) clearTimeout(this.hideTimer);
     if (this.removeTimer) clearTimeout(this.removeTimer);
     const typeMapIcon =


### PR DESCRIPTION
 API调用，多次调用时，对于后续未传入的参数，会重复使用之前传入的参数值的问题。修改为，对未传入的参数使用默认值。
fix #225