### PR TITLE
fix(swiper): use createSelectorQuery in nextTick when attached

### DIFF
--- a/src/swiper/swiper.ts
+++ b/src/swiper/swiper.ts
@@ -127,16 +127,18 @@ export default class Swiper extends SuperComponent {
       valueKey: 'current',
       strict: false,
     });
-    this.createSelectorQuery()
-      .select('#swiper')
-      .boundingClientRect((rect) => {
-        this.setData({
-          _width: rect.width,
-          _height: rect.height,
-        });
-        this.initCurrent();
-      })
-      .exec();
+    wx.nextTick(() => {
+      this.createSelectorQuery()
+        .select('#swiper')
+        .boundingClientRect((rect) => {
+          this.setData({
+            _width: rect.width,
+            _height: rect.height,
+          });
+          this.initCurrent();
+        })
+        .exec();
+    });
   }
 
   detached() {


### PR DESCRIPTION
QQ 小程序在 attached 中对 createSelectorQuery 的调用需放置在 wx.nextTick 中