### PR TITLE
fix(swipe-cell): use more compatible syntax

### DIFF
--- a/src/swipe-cell/swipe-cell.wxs
+++ b/src/swipe-cell/swipe-cell.wxs
@@ -77,7 +77,8 @@ var range = function (num, min, max) {
   return Math.min(Math.max(num, min), max);
 };
 
-var swipeMove = function (_offset = 0) {
+var swipeMove = function (_offset) {
+  if (_offset === undefined) _offset = 0;
   state.offset = range(_offset, -state.rightWidth, +state.leftWidth);
   var transform = 'translate3d(' + state.offset + 'px, 0, 0)';
   var transition = state.dragging ? 'none' : 'transform .6s cubic-bezier(0.18, 0.89, 0.32, 1)';


### PR DESCRIPTION
QQ 小程序编译 wxs 时使用函数默认参数值会报错；这里修改为兼容的语法；