### PR TITLE
fix(toast): correct loading color

### DIFF
--- a/src/toast/toast.less
+++ b/src/toast/toast.less
@@ -1,5 +1,6 @@
-// @import (css) '../common/index.wxss';
-.t-toast {
+@import '../common/style/index.less';
+
+.@{prefix}-toast {
   &__bg {
     width: 100%;
     height: 100%;

--- a/src/toast/toast.wxml
+++ b/src/toast/toast.wxml
@@ -16,7 +16,8 @@
       theme="circular"
       size="{{direction === 'row' ? '42rpx' : '96rpx'}}"
       loading
-      t-class-indicator="indicator-blue"
+      inherit-color
+      style="color: white"
       layout="vertical"
     />
     <slot name="icon" />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

Toast 在 loading 的状态下，标志的颜色是蓝色的，应该是白色

### 📝 更新日志

- fix(toast): 更正 loading 标志的颜色

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
