### PR TITLE
fix: remove component instance on setData

### DIFF
--- a/src/tab-bar/tab-bar-item.ts
+++ b/src/tab-bar/tab-bar-item.ts
@@ -12,8 +12,8 @@ export default class TabbarItem extends SuperComponent {
       type: 'ancestor',
       linked(parent) {
         const [activeColor, color] = parent.data.color;
+        this.data.parent = parent;
         this.setData({
-          parent,
           color,
           activeColor,
           split: parent.data.split,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
- 无

### 💡 需求背景和解决方案

- 问题：app实例上有包含循环引用时，由于setData会序列化整个app实例导致报错
- 解决方案：把setData app实例改为直接赋值，顺便减少setData计算量
### 📝 更新日志

-  fix(tab-bar-item): fix the problem of SetData serialization error when this contains the current instance, optimize SetData, and delete irrelevant rendering data

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
