### PR TITLE
修复navbar变量名的错误，修复dialog取消按钮无法传递Object的问题

### DIFF
--- a/src/dialog/dialog.wxml
+++ b/src/dialog/dialog.wxml
@@ -49,7 +49,7 @@
         <template
           is="button"
           class="{{classPrefix}}__footer-button-host"
-          data="{{...confirmBtn, block: true, type: 'cancel', externalClass: classPrefix + '__button ' + classPrefix + '__button-cancel ' + (cancelBtn ? classPrefix + '__button-half ' : ' ') + prefix + '-class-cancel'}}"
+          data="{{...cancelBtn, block: true, type: 'cancel', externalClass: classPrefix + '__button ' + classPrefix + '__button-cancel ' + (cancelBtn ? classPrefix + '__button-half ' : ' ') + prefix + '-class-cancel'}}"
         ></template>
       </block>
       <slot name="cancelBtn" />

--- a/src/navbar/navbar.less
+++ b/src/navbar/navbar.less
@@ -14,7 +14,7 @@
   --navbar-height: 44px;
   --navbar-right: 190rpx; // 默认右上角胶囊按钮宽度，组件会在初始化时尝试自动获取胶囊按钮宽度并覆写该值
   --narbar-padding-top: 20px; // 导航栏顶部间距，组件会在初始化时尝试取右侧系统胶囊位置进行覆盖
-  --capsule-wight: 174rpx;
+  --capsule-width: 174rpx;
 
   overflow: hidden;
 
@@ -78,7 +78,7 @@
   &__capsule {
     box-sizing: border-box;
     margin-left: 24rpx;
-    width: var(--capsule-wight);
+    width: var(--capsule-width);
     height: var(--capsule-height);
     line-height: var(--capsule-height);
     border-radius: 16rpx * 2;

--- a/src/navbar/navbar.ts
+++ b/src/navbar/navbar.ts
@@ -99,14 +99,12 @@ export default class Navbar extends SuperComponent {
         const ios = !!(res.system.toLowerCase().search('ios') + 1);
         const navbarHeight = ios ? 44 : 48;
         const boxStyleList = [];
-        boxStyleList.push(
-          `--narbar-padding-top:${(rect.bottom + rect.top) / 2 - navbarHeight / 2}px;`,
-        );
+        boxStyleList.push(`--narbar-padding-top:${(rect.bottom + rect.top) / 2 - navbarHeight / 2}px;`);
         if (rect && res?.windowWidth) {
           boxStyleList.push(`--navbar-right:${res.windowWidth - rect.left}px;`); // 导航栏右侧小程序胶囊按钮宽度
         }
         boxStyleList.push(`--capsule-height:${rect.height}px;`); // 胶囊高度
-        boxStyleList.push(`--capsule-wight:${rect.width}px;`); // 胶囊宽度
+        boxStyleList.push(`--capsule-width:${rect.width}px;`); // 胶囊宽度
         boxStyleList.push(`--navbar-height:${navbarHeight}px;`); // navbar高度
         this.setData({
           ios,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. `navbar`有一个CSS变量的拼写错误
2. `dialog`组件，在取消按钮传递对象作为props时，会使用确定按钮的参数

```js
Component({
    data: {
        cancelBtn: { content: '取消' },
        confirmBtn: { content: '确定', disabled: true },
    },
})

```

```jsx
<t-dialog confirm-btn="{{ confirmBtn }}" cancel-btn="{{ cancelBtn }}"></t-dialog>
```

![image](https://user-images.githubusercontent.com/19792747/173496313-36167ddf-1e01-4d90-b0d1-12fdd661d32a.png)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(navbar): 修复变量名 `--capsule-wight` 为 `--capsule-width` 的拼写错误
- fix(dialog): 修复取消按钮传递Object显示不正确的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
