### PR TITLE
feat(dropdown-menu): add keys property and rename overlay to show-ove…

### DIFF
--- a/src/dropdown-menu/README.md
+++ b/src/dropdown-menu/README.md
@@ -180,14 +180,15 @@ Page({
 active-color | String | - | 【讨论中】菜单标题和选项的选中态颜色 | N
 close-on-click-overlay | Boolean | true | 是否在点击遮罩层后关闭菜单 | N
 duration | String / Number | 200 | 动画时长 | N
-overlay | Boolean | true | 是否显示遮罩层 | N
-z-index | Number | 11600 | 组件层级，样式默认为 11600 | N
+show-overlay | Boolean | true | 是否显示遮罩层 | N
+z-index | Number | 11600 | 菜单栏 z-index 层级 | N
 
 ### DropdownItem Props
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 disabled | Boolean | false | 是否禁用 | N
+keys | Object | - | 用来定义 value / label 在 `options` 中对应的字段别名。TS 类型：`KeysType` | N
 label | String | - | 标题 | N
 multiple | Boolean | false | 是否多选 | N
 options | Array | [] | 选项数据。TS 类型：`Array<TdDropdownItemOption>` `interface TdDropdownItemOption { label: string;disabled: boolean;value: TdDropdownItemOptionValueType; [key: string]: any }`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/dropdown-menu/type.ts) | N

--- a/src/dropdown-menu/dropdown-item-props.ts
+++ b/src/dropdown-menu/dropdown-item-props.ts
@@ -11,6 +11,10 @@ const props: TdDropdownItemProps = {
     type: Boolean,
     value: false,
   },
+  /** 用来定义 value / label 在 `options` 中对应的字段别名 */
+  keys: {
+    type: Object,
+  },
   /** 标题 */
   label: {
     type: String,

--- a/src/dropdown-menu/dropdown-item.ts
+++ b/src/dropdown-menu/dropdown-item.ts
@@ -28,7 +28,9 @@ export default class DropdownMenuItem extends SuperComponent {
     hasChanged: false,
     duration: menuProps.duration.value,
     zIndex: menuProps.zIndex.value,
-    overlay: menuProps.overlay.value,
+    overlay: menuProps.showOverlay.value,
+    labelAlias: 'label',
+    valueAlias: 'value',
   };
 
   parent = null;
@@ -37,14 +39,14 @@ export default class DropdownMenuItem extends SuperComponent {
     './dropdown-menu': {
       type: 'parent',
       linked(target) {
-        const { zIndex, duration, overlay } = target.properties;
+        const { zIndex, duration, showOverlay } = target.properties;
 
         this.parent = target;
         this.getParentBottom(target);
         this.setData({
           zIndex,
           duration,
-          overlay,
+          showOverlay,
         });
       },
     },
@@ -74,6 +76,12 @@ export default class DropdownMenuItem extends SuperComponent {
     },
     label() {
       this.parent?.getAllItems();
+    },
+    keys(obj) {
+      this.setData({
+        labelAlias: obj.label || 'label',
+        valueAlias: obj.value || 'value',
+      });
     },
   };
 

--- a/src/dropdown-menu/dropdown-item.wxml
+++ b/src/dropdown-menu/dropdown-item.wxml
@@ -16,9 +16,9 @@
               icon="stroke-line"
               align="right"
               t-class="radio"
-              t-class-label="radio__label radio__label--{{value == item.value ? 'active' : ''}}"
-              value="{{item.value}}"
-              label="{{item.label}}"
+              t-class-label="radio__label radio__label--{{value == item[valueAlias] ? 'active' : ''}}"
+              value="{{item[valueAlias]}}"
+              label="{{item[labelAlias]}}"
               disabled="{{item.disabled}}"
             ></t-radio>
           </t-radio-group>
@@ -35,8 +35,8 @@
               <t-checkbox
                 class="{{classPrefix}}__checkbox-item"
                 theme="tag"
-                value="{{item.value}}"
-                label="{{item.label}}"
+                value="{{item[valueAlias]}}"
+                label="{{item[labelAlias]}}"
                 disabled="{{item.disabled}}"
               ></t-checkbox>
             </block>
@@ -57,10 +57,10 @@
               wx:key="index"
               bind:tap="handleTreeClick"
               data-level="{{level}}"
-              data-value="{{item.value}}"
-              class="{{classPrefix}}__tree-item {{item.value === value[level] ? classPrefix + '__tree-item--active' : '' }}"
+              data-value="{{item[valueAlias]}}"
+              class="{{classPrefix}}__tree-item {{item[valueAlias] === value[level] ? classPrefix + '__tree-item--active' : '' }}"
             >
-              {{item.label}}
+              {{item[labelAlias]}}
             </view>
           </block>
 
@@ -71,11 +71,11 @@
                   wx:for="{{treeOptions[level]}}"
                   wx:key="value"
                   t-class="radio"
-                  t-class-label="radio__label radio__label--{{value[level] === item.value ? 'active' : ''}}"
-                  value="{{item.value}}"
+                  t-class-label="radio__label radio__label--{{value[level] === item[valueAlias] ? 'active' : ''}}"
+                  value="{{item[valueAlias]}}"
                   borderless
                   align="right"
-                  >{{item.label}}</t-radio
+                  >{{item[labelAlias]}}</t-radio
                 >
               </t-radio-group>
             </block>
@@ -86,10 +86,10 @@
                   wx:key="value"
                   align="right"
                   t-class="radio"
-                  t-class-label="radio__label radio__label--{{value[level] === item.value ? 'active' : ''}}"
+                  t-class-label="radio__label radio__label--{{value[level] === item[valueAlias] ? 'active' : ''}}"
                   borderless
-                  value="{{item.value}}"
-                  >{{item.label}}</t-checkbox
+                  value="{{item[valueAlias]}}"
+                  >{{item[labelAlias]}}</t-checkbox
                 >
               </t-checkbox-group>
             </block>
@@ -116,7 +116,7 @@
     </view>
   </view>
   <view
-    wx:if="{{show && overlay}}"
+    wx:if="{{show && showOverlay}}"
     class="{{prefix}}-mask"
     bind:tap="handleMaskClick"
     style="z-index: {{zIndex - 1}}"

--- a/src/dropdown-menu/dropdown-menu.wxml
+++ b/src/dropdown-menu/dropdown-menu.wxml
@@ -2,6 +2,7 @@
   <view class="{{ classPrefix }}__bar" style="z-index: {{zIndex}}" id="t-bar">
     <view
       wx:for="{{menus}}"
+      wx:key="index"
       bindtap="toggleDropdown"
       data-index="{{index}}"
       class="{{ classPrefix }}__item {{ activeIdx == index ? prefix + '-is-active' : ''}} {{ item.disabled ? prefix + '-is-disabled' : ''}}"

--- a/src/dropdown-menu/props.ts
+++ b/src/dropdown-menu/props.ts
@@ -23,11 +23,11 @@ const props: TdDropdownMenuProps = {
     value: 200,
   },
   /** 是否显示遮罩层 */
-  overlay: {
+  showOverlay: {
     type: Boolean,
     value: true,
   },
-  /** 组件层级，样式默认为 11600 */
+  /** 菜单栏 z-index 层级 */
   zIndex: {
     type: Number,
     value: 11600,

--- a/src/dropdown-menu/type.ts
+++ b/src/dropdown-menu/type.ts
@@ -4,6 +4,8 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
+import { KeysType } from '../common/common';
+
 export interface TdDropdownMenuProps {
   /**
    * 【讨论中】菜单标题和选项的选中态颜色
@@ -34,7 +36,7 @@ export interface TdDropdownMenuProps {
    * 是否显示遮罩层
    * @default true
    */
-  overlay?: {
+  showOverlay?: {
     type: BooleanConstructor;
     value?: boolean;
   };
@@ -56,6 +58,13 @@ export interface TdDropdownItemProps {
   disabled?: {
     type: BooleanConstructor;
     value?: boolean;
+  };
+  /**
+   * 用来定义 value / label 在 `options` 中对应的字段别名
+   */
+  keys?: {
+    type: ObjectConstructor;
+    value?: KeysType;
   };
   /**
    * 标题


### PR DESCRIPTION
…rlay

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #530 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
增加 keys 属性以支持自定义 label 和 value 的字段名

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- DropdownItem: 新增 `keys` 属性以支持自定义 `label` 和 `value` 的字段名
- DropdownMenu: 属性 `overlay` 更名为 `showOverlay`