### PR TITLE
fix(drawer): placement remove top and bottom

### DIFF
--- a/src/drawer/README.md
+++ b/src/drawer/README.md
@@ -33,10 +33,10 @@ isComponent: true
 close-on-overlay-click | Boolean | true | 点击蒙层时是否触发抽屉关闭事件 | N
 destroy-on-close | Boolean | false | 抽屉关闭时是否销毁节点 | N
 items | Array | - | 抽屉里的列表项。TS 类型：`DrawerItem[] ` `interface DrawerItem { title: string; icon: string; }`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/drawer/type.ts) | N
-placement | String | right | 抽屉方向。可选项：left/right/top/bottom | N
+placement | String | right | 抽屉方向。可选项：left/right | N
 show-overlay | Boolean | true | 是否显示遮罩层 | N
 visible | Boolean | false | 组件是否可见 | N
-z-index | Number | 11500 | 组件层级，样式默认为 11500 | N
+z-index | Number | - | 抽屉层级，样式默认为 1500 | N
 
 ### Drawer Events
 

--- a/src/drawer/drawer.wxml
+++ b/src/drawer/drawer.wxml
@@ -2,7 +2,7 @@
   bind:visible-change="visibleChange"
   visible="{{visible}}"
   zIndex="{{zIndex}}"
-  placement="{{placement}}"
+  placement="{{placement == 'right' ? 'right' : 'left'}}"
   showOverlay="{{showOverlay}}"
   destroyOnClose="{{destroyOnClose}}"
   closeOnOverlayClick="{{closeOnOverlayClick}}"

--- a/src/drawer/props.ts
+++ b/src/drawer/props.ts
@@ -35,10 +35,9 @@ const props: TdDrawerProps = {
     type: Boolean,
     value: false,
   },
-  /** 组件层级，样式默认为 11500 */
+  /** 抽屉层级，样式默认为 1500 */
   zIndex: {
     type: Number,
-    value: 11500,
   },
 };
 

--- a/src/drawer/type.ts
+++ b/src/drawer/type.ts
@@ -34,7 +34,7 @@ export interface TdDrawerProps {
    */
   placement?: {
     type: StringConstructor;
-    value?: 'left' | 'right' | 'top' | 'bottom';
+    value?: 'left' | 'right';
   };
   /**
    * 是否显示遮罩层


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
由于目前的设计，是不支持 placement = top || bottom 的
因此，移除这两个类型的支持。传入 right 时为 right 否则为 left

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Drawer): 调整 `placement` 属性，只支持 `left` 和 `right`
