### PR TITLE
fix(loading): 修复text为空时，实际大小与视觉大小不一致问题

### DIFF
--- a/src/loading/loading.wxml
+++ b/src/loading/loading.wxml
@@ -33,12 +33,12 @@
         ></view>
       </block>
     </view>
-    <view class="{{prefix}}-class-text" wx:if="{{text}}">
+    <view class="{{prefix}}-class-text">
       <view wx:if="{{theme === 'error'}}">
         <span>加载失败</span>
         <span class="{{classPrefix}}__refresh-btn" bind:tap="refreshPage">刷新</span>
       </view>
-      <view class="{{classPrefix}}__text" wx:else>
+      <view class="{{classPrefix}}__text" wx:if="{{text}}">
         {{text}}
         <slot name="text" />
       </view>

--- a/src/loading/loading.wxml
+++ b/src/loading/loading.wxml
@@ -39,7 +39,7 @@
         <span class="{{classPrefix}}__refresh-btn" bind:tap="refreshPage">刷新</span>
       </view>
       <view class="{{classPrefix}}__text" wx:if="{{text}}">
-        <view wx:if="{{text !== 'slot'}}"> {{text}} </view>
+        <text wx:if="{{text !== 'slot'}}"> {{text}} </text>
         <slot name="text" />
       </view>
     </view>

--- a/src/loading/loading.wxml
+++ b/src/loading/loading.wxml
@@ -33,7 +33,7 @@
         ></view>
       </block>
     </view>
-    <view class="{{prefix}}-class-text">
+    <view class="{{prefix}}-class-text" wx:if="{{text}}">
       <view wx:if="{{theme === 'error'}}">
         <span>加载失败</span>
         <span class="{{classPrefix}}__refresh-btn" bind:tap="refreshPage">刷新</span>

--- a/src/loading/loading.wxml
+++ b/src/loading/loading.wxml
@@ -39,7 +39,7 @@
         <span class="{{classPrefix}}__refresh-btn" bind:tap="refreshPage">刷新</span>
       </view>
       <view class="{{classPrefix}}__text" wx:if="{{text}}">
-        {{text}}
+        <view wx:if="{{text !== 'slot'}}"> {{text}} </view>
         <slot name="text" />
       </view>
     </view>


### PR DESCRIPTION
fix #618

### 🤔 这个 PR 的性质是？
- [x] 日常 bug 修复

### 🔗 相关 Issue
fix(loading): 修复text为空时，实际大小与视觉大小不一致问题
https://github.com/Tencent/tdesign-miniprogram/issues/618

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Loading): 修复 `text` 为空时仍渲染非空节点的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
