### PR TITLE
fix(dropdown-menu): enable close on click overlay

### DIFF
--- a/src/dropdown-menu/dropdown-item.wxml
+++ b/src/dropdown-menu/dropdown-item.wxml
@@ -9,6 +9,7 @@
     custom-style="position: absolute;"
     overlayProps="{{ { customStyle: 'position: absolute' } }}"
     bind:leaved="onLeaved"
+    bind:visible-change="handleMaskClick"
     class="{{classPrefix}}__popup-host"
     t-class-content="{{contentClasses}} {{classPrefix}}__content"
   >


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #677 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修复点击遮罩层不触发关闭的问题

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DropdownMenu): 修复 `closeOnClickOverlay` 不生效的问题
