### PR TITLE
fix: resolve function with the same name

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rollup/plugin-node-resolve": "^13.0.5",
     "@types/jest": "^27.0.3",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
-    "@typescript-eslint/parser": "^5.6.0",
+    "@typescript-eslint/parser": "~5.35.0",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vitejs/plugin-vue-jsx": "^1.1.7",
     "@vue/compiler-sfc": "^3.2.4",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -48,7 +48,7 @@ export const styles = function (styleObj) {
     .join('; ');
 };
 
-export const requestAnimationFrame = function (cb: Function) {
+export const getAnimationFrame = function (cb: Function) {
   return wx
     .createSelectorQuery()
     .selectViewport()

--- a/src/notice-bar/notice-bar.ts
+++ b/src/notice-bar/notice-bar.ts
@@ -1,5 +1,5 @@
 import { SuperComponent, wxComponent, ComponentsOptionsType } from '../common/src/index';
-import { getRect, requestAnimationFrame } from '../common/utils';
+import { getRect, getAnimationFrame } from '../common/utils';
 import props from './props';
 import config from '../common/config';
 
@@ -73,7 +73,7 @@ export default class NoticeBar extends SuperComponent {
       // 获取外部容器和滚动内容的宽度
       const warpID = `.${name}__content-wrap`;
       const nodeID = `.${name}__content`;
-      requestAnimationFrame(() => {
+      getAnimationFrame(() => {
         Promise.all([getRect(this, nodeID), getRect(this, warpID)]).then(([nodeRect, wrapRect]) => {
           const { marquee } = this.properties;
           const speeding = marquee.speed;
@@ -118,7 +118,7 @@ export default class NoticeBar extends SuperComponent {
           .export(),
       });
 
-      requestAnimationFrame(() => {
+      getAnimationFrame(() => {
         // 滚动内容: 最终位置
         this.setData({
           animationData: wx


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
#813 


### 💡 需求背景和解决方案
原因：common/utils.js 中的 requestAnimationFrame 函数重名
解决方案：将 common/utils.js 中的 requestAnimationFrame 函数更名为  getAnimationFrame

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(NoticeBar): 解决函数同名导致控制台报错 

