### PR TITLE
style(icon): remove the css property speak

### DIFF
--- a/src/icon/icon.less
+++ b/src/icon/icon.less
@@ -25,7 +25,6 @@
 }
 
 .@{prefix}-icon-base {
-  speak: none;
   font-style: normal;
   font-weight: normal;
   font-variant: normal;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
`speak` 属性用于指定文本是否用于听觉媒体，CSS3中弃用，该属性不支持主要浏览器，对无障碍支持度不太友好，小程序中无法识别该属性，故直接移除。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Icon): 移除 `CSS` 属性 `speak`

