### PR TITLE
fix(Dialog&&Message): command line close supports custom selectors

### DIFF
--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -79,8 +79,9 @@ export default {
       instance._onCancel = reject;
     });
   },
-  close() {
-    const instance = getInstance();
+  close(options: DialogComfirmOptionsType) {
+    const { context, selector = '#t-dialog' } = { ...options };
+    const instance = getInstance(context, selector);
     if (instance) {
       instance.close();
       return Promise.resolve();

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -35,8 +35,9 @@ export default {
   error(options: MessageActionOptionsType) {
     return showMessage(options, MessageType.error);
   },
-  hide() {
-    const instance = getInstance();
+  hide(options: MessageActionOptionsType) {
+    const { context, selector = '#t-message' } = { ...options };
+    const instance = getInstance(context, selector);
     if (!instance) {
       return;
     }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue
#893 


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 函数式`Dialog.close()` 关闭窗体支持自定义  `selector`
- fix(Message): 函数式`Dialog.hide()` 关闭窗体支持自定义  `selector`
