### PR TITLE
fix(Tabs): fix tabs left layout

### DIFF
--- a/src/tabs/__test__/__snapshots__/demo.test.js.snap
+++ b/src/tabs/__test__/__snapshots__/demo.test.js.snap
@@ -430,24 +430,65 @@ exports[`Tabs Tabs with-content demo works fine 1`] = `
     bind:click="onTabsClick"
   >
     <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
       label="标签页一"
       value="0"
     >
       标签一内容
     </t-tab-panel>
     <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
       label="标签页二"
       value="1"
     >
       标签二内容
     </t-tab-panel>
     <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
       label="标签页三"
       value="2"
     >
       标签三内容
     </t-tab-panel>
     <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
+      label="标签页四"
+      value="3"
+    >
+      标签四内容
+    </t-tab-panel>
+  </t-tabs>
+  <t-tabs
+    animation=""
+    defaultValue="{{0}}"
+    placement="left"
+    tClass="custom-tabs"
+    bind:change="onTabsChange"
+    bind:click="onTabsClick"
+  >
+    <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
+      label="标签页一"
+      value="0"
+    >
+      标签一内容
+    </t-tab-panel>
+    <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
+      label="标签页二"
+      value="1"
+    >
+      标签二内容
+    </t-tab-panel>
+    <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
+      label="标签页三"
+      value="2"
+    >
+      标签三内容
+    </t-tab-panel>
+    <t-tab-panel
+      customStyle="display:flex;justify-content:center;align-items:center;min-height: 120px"
       label="标签页四"
       value="3"
     >

--- a/src/tabs/_example/base/index.wxss
+++ b/src/tabs/_example/base/index.wxss
@@ -1,11 +1,3 @@
 .custom-tabs {
   margin-bottom: 32rpx;
 }
-
-.custom-tabs t-tab-panel {
-  text-align: center;
-  justify-content: center;
-  max-height: 172rpx;
-  line-height: 172rpx;
-  color: rgba(0, 0, 0, 0.26);
-}

--- a/src/tabs/_example/with-content/index.js
+++ b/src/tabs/_example/with-content/index.js
@@ -1,4 +1,8 @@
 Component({
+  data: {
+    tabPanelCustomStyle: 'display:flex;justify-content:center;align-items:center;min-height: 120px',
+  },
+
   methods: {
     onTabsChange(event) {
       console.log(`Change tab, tab-panel value is ${event.detail.value}.`);

--- a/src/tabs/_example/with-content/index.wxml
+++ b/src/tabs/_example/with-content/index.wxml
@@ -5,8 +5,22 @@
   animation="{{animation}}"
   t-class="custom-tabs"
 >
-  <t-tab-panel label="标签页一" value="0">标签一内容</t-tab-panel>
-  <t-tab-panel label="标签页二" value="1">标签二内容</t-tab-panel>
-  <t-tab-panel label="标签页三" value="2">标签三内容</t-tab-panel>
-  <t-tab-panel label="标签页四" value="3">标签四内容</t-tab-panel>
+  <t-tab-panel label="标签页一" value="0" customStyle="{{tabPanelCustomStyle}}">标签一内容</t-tab-panel>
+  <t-tab-panel label="标签页二" value="1" customStyle="{{tabPanelCustomStyle}}">标签二内容</t-tab-panel>
+  <t-tab-panel label="标签页三" value="2" customStyle="{{tabPanelCustomStyle}}">标签三内容</t-tab-panel>
+  <t-tab-panel label="标签页四" value="3" customStyle="{{tabPanelCustomStyle}}">标签四内容</t-tab-panel>
+</t-tabs>
+
+<t-tabs
+  defaultValue="{{0}}"
+  bind:change="onTabsChange"
+  bind:click="onTabsClick"
+  animation="{{animation}}"
+  placement="left"
+  t-class="custom-tabs"
+>
+  <t-tab-panel label="标签页一" value="0" customStyle="{{tabPanelCustomStyle}}">标签一内容</t-tab-panel>
+  <t-tab-panel label="标签页二" value="1" customStyle="{{tabPanelCustomStyle}}">标签二内容</t-tab-panel>
+  <t-tab-panel label="标签页三" value="2" customStyle="{{tabPanelCustomStyle}}">标签三内容</t-tab-panel>
+  <t-tab-panel label="标签页四" value="3" customStyle="{{tabPanelCustomStyle}}">标签四内容</t-tab-panel>
 </t-tabs>

--- a/src/tabs/_example/with-content/index.wxss
+++ b/src/tabs/_example/with-content/index.wxss
@@ -1,7 +1,3 @@
-.custom-tabs t-tab-panel {
-  text-align: center;
-  justify-content: center;
-  height: 172rpx;
-  line-height: 172rpx;
-  color: rgba(0, 0, 0, 0.26);
+.custom-tabs {
+  margin-bottom: 32rpx;
 }

--- a/src/tabs/tabs.less
+++ b/src/tabs/tabs.less
@@ -289,6 +289,7 @@
       top: 0;
       left: @tab-item-width--vertical;
       overflow: hidden;
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 演示代码改进


### 💡 需求背景和解决方案
需求： placement='left' 时，面板内容不显示
原因： 绝对定位元素被遮挡
方案：给被遮挡的绝对定位元素设置 z-index 值


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复 placement='left' 时，面板内容不显示问题

