### PR TITLE
fix(calendar): enable without confirm button

### DIFF
--- a/src/calendar/README.en-US.md
+++ b/src/calendar/README.en-US.md
@@ -6,19 +6,21 @@
 name | type | default | description | required
 -- | -- | -- | -- | --
 confirm-btn | String / Object / Slot | '' | [see more ts definition](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
-custom-style `v0.25.0` | String | - | \- | N
+custom-style | String | - | `0.25.0` | N
 first-day-of-week | Number | 0 | \- | N
-format | Function | - | Typescript：`(day: TDate) => TDate` `type TDateType = 'selected' | 'disabled' | 'start' | 'centre' | 'end' | ''; ` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string; }`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
-max-date | Number / Date | - | Typescript：`number | Date` | N
-min-date | Number / Date | - | Typescript：`number | Date` | N
-title | String / Slot | - | \- | N
-type | String | 'single' | options：single/multiple/range | N
-value | Number / Array / Date | - | Typescript：`number | Date | TCalendarValue[] ` `type TCalendarValue = number | Date`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
+format | Function | - | Typescript：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
+max-date | Number | - | \- | N
+min-date | Number | - | \- | N
+title | String / Slot | '' | \- | N
+type | String | single | options：single/multiple/range | N
+value | Number / Array | - | Typescript：`number \| number[]` | N
+default-value | Number / Array | undefined | uncontrolled property。Typescript：`number \| number[]` | N
 visible | Boolean | false | \- | N
 
 ### Calendar Events
 
 name | params | description
 -- | -- | --
-confirm | `(value: Date)` | \-
-select | `(value: Date)` | \-
+change | `(value: timestamp)` | `0.28.0`
+confirm | `(value: timestamp)` | \-
+select | `(value: timestamp)` | `0.28.0`

--- a/src/calendar/README.md
+++ b/src/calendar/README.md
@@ -42,19 +42,21 @@ isComponent: true
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 confirm-btn | String / Object / Slot | '' | 确认按钮。值为 null 则不显示确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
-custom-style `v0.25.0` | String | - | 自定义组件样式 | N
+custom-style | String | - | `0.25.0`。自定义组件样式 | N
 first-day-of-week | Number | 0 | 第一天从星期几开始，默认 0 = 周日 | N
-format | Function | - | 用于格式化日期的函数。TS 类型：`(day: TDate) => TDate` `type TDateType = 'selected' | 'disabled' | 'start' | 'centre' | 'end' | ''; ` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string; }`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
-max-date | Number / Date | - | 最大可选的日期，不传则默认半年后。TS 类型：`number | Date` | N
-min-date | Number / Date | - | 最小可选的日期，不传则默认今天。TS 类型：`number | Date` | N
-title | String / Slot | - | 标题，不传默认为“请选择日期” | N
-type | String | 'single' | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
-value | Number / Array / Date | - | 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组。TS 类型：`number | Date | TCalendarValue[] ` `type TCalendarValue = number | Date`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
+format | Function | - | 用于格式化日期的函数。TS 类型：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/calendar/type.ts) | N
+max-date | Number | - | 最大可选的日期，不传则默认半年后 | N
+min-date | Number | - | 最小可选的日期，不传则默认今天 | N
+title | String / Slot | '' | 标题，不传默认为“请选择日期” | N
+type | String | single | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
+value | Number / Array | - | 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组。TS 类型：`number \| number[]` | N
+default-value | Number / Array | undefined | 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组。非受控属性。TS 类型：`number \| number[]` | N
 visible | Boolean | false | 是否显示日历 | N
 
 ### Calendar Events
 
 名称 | 参数 | 描述
 -- | -- | --
-confirm | `(value: Date)` | 点击确认按钮时触发
-select | `(value: Date)` | 选择日期时触发
+change | `(value: timestamp)` | `0.28.0`。不显示 confirm-btn 时，完成选择时触发（暂不支持 type = multiple）
+confirm | `(value: timestamp)` | 点击确认按钮时触发
+select | `(value: timestamp)` | `0.28.0`。点击日期时触发

--- a/src/calendar/__test__/__snapshots__/demo.test.js.snap
+++ b/src/calendar/__test__/__snapshots__/demo.test.js.snap
@@ -8,10 +8,29 @@ exports[`Calendar Calendar base demo works fine 1`] = `
   />
   <t-cell
     arrow="{{true}}"
+    note=""
     title="单个选择日历"
     bind:tap="handleCalendar"
   />
 </base>
+`;
+
+exports[`Calendar Calendar custom-button demo works fine 1`] = `
+<custom-button>
+  <t-calendar
+    confirmBtn="{{null}}"
+    minDate="{{1641052800000}}"
+    type="range"
+    visible="{{false}}"
+    bind:change="onChange"
+  />
+  <t-cell
+    arrow="{{true}}"
+    note=""
+    title="不显示按钮"
+    bind:tap="handleCalendar"
+  />
+</custom-button>
 `;
 
 exports[`Calendar Calendar custom-range demo works fine 1`] = `

--- a/src/calendar/__test__/demo.test.js
+++ b/src/calendar/__test__/demo.test.js
@@ -5,7 +5,7 @@
 import simulate from 'miniprogram-simulate';
 import path from 'path';
 
-const mapper = ['base', 'custom-range', 'custom-text', 'multiple', 'range'];
+const mapper = ['base', 'custom-button', 'custom-range', 'custom-text', 'multiple', 'range'];
 
 describe('Calendar', () => {
   mapper.forEach((demoName) => {

--- a/src/calendar/__test__/index.test.js
+++ b/src/calendar/__test__/index.test.js
@@ -40,24 +40,52 @@ describe('calendar', () => {
     const comp = simulate.render(id);
     comp.attach(document.createElement('parent-wrapper'));
 
-    const $base = comp.querySelector('#base');
-    const [$disbledItem, $activeItem] = $base.querySelectorAll('.t-calendar__dates-item');
-    const $confirmBtn = $base.querySelector('.t-calendar__confirm-btn');
+    const $calendar = comp.querySelector('#base');
+    const [$disbledItem, , $activeItem] = $calendar.querySelectorAll('.t-calendar__dates-item');
+    const $confirmBtn = $calendar.querySelector('.t-calendar__confirm-btn');
+
+    expect($calendar.instance.data.value).toBe(date.getTime());
 
     $disbledItem.dispatchEvent('tap');
     await simulate.sleep();
 
-    expect($base.instance.base.value).toBe(null);
+    expect($calendar.instance.data.value).toBe(date.getTime());
 
     $activeItem.dispatchEvent('tap');
     await simulate.sleep();
 
-    expect($base.instance.base.value).toStrictEqual(date);
+    expect($calendar.instance.data.value).toBe(date.getTime()); // 点击时不修改 value 值
 
     $confirmBtn.dispatchEvent('tap');
     await simulate.sleep();
 
     expect(onConfirm).toHaveBeenCalled();
+    expect($calendar.instance.data.value).toBe(date.getTime() + 24 * 3600 * 1000);
+  });
+
+  it(':without-button', async () => {
+    const date = new Date(2022, 0, 1);
+    const id = simulate.load({
+      template: `<t-calendar minDate="{{min}}" confirm-btn="{{null}}" id="base" visible></t-calendar>`,
+      data: {
+        min: date.getTime(),
+      },
+      usingComponents: {
+        't-calendar': calendar,
+      },
+    });
+    const comp = simulate.render(id);
+    comp.attach(document.createElement('parent-wrapper'));
+
+    const $calendar = comp.querySelector('#base');
+    const [, $activeItem] = $calendar.querySelectorAll('.t-calendar__dates-item');
+
+    expect($calendar.instance.data.value).toBe(date.getTime());
+
+    $activeItem.dispatchEvent('tap');
+    await simulate.sleep();
+
+    expect($calendar.instance.data.value).toBe(date.getTime() + 24 * 3600 * 1000);
   });
 
   it(':confirm', async () => {
@@ -74,13 +102,13 @@ describe('calendar', () => {
     const comp = simulate.render(id);
     comp.attach(document.createElement('parent-wrapper'));
 
-    const $base = comp.querySelector('#base');
-    const $closeBtn = $base.querySelector('.t-calendar__close-btn');
+    const $calendar = comp.querySelector('#base');
+    const $closeBtn = $calendar.querySelector('.t-calendar__close-btn');
 
     $closeBtn.dispatchEvent('tap');
     await simulate.sleep();
 
-    expect($base.instance.visible).toBeFalsy();
+    expect($calendar.instance.visible).toBeFalsy();
   });
 
   it(':custom button', async () => {
@@ -96,8 +124,8 @@ describe('calendar', () => {
     const comp = simulate.render(id);
     comp.attach(document.createElement('parent-wrapper'));
 
-    const $base = comp.querySelector('#base');
-    const $confirmBtn = $base.querySelector('.t-calendar__confirm-btn');
+    const $calendar = comp.querySelector('#base');
+    const $confirmBtn = $calendar.querySelector('.t-calendar__confirm-btn');
 
     $confirmBtn.dispatchEvent('tap');
     await simulate.sleep();

--- a/src/calendar/_example/base/index.wxml
+++ b/src/calendar/_example/base/index.wxml
@@ -1,2 +1,2 @@
 <t-calendar visible="{{visible}}" bind:confirm="handleConfirm" />
-<t-cell arrow title="单个选择日历" bind:tap="handleCalendar" />
+<t-cell arrow title="单个选择日历" bind:tap="handleCalendar" note="{{note}}" />

--- a/src/calendar/_example/calendar.json
+++ b/src/calendar/_example/calendar.json
@@ -4,6 +4,7 @@
     "multiple": "./multiple",
     "range": "./range",
     "custom-text": "./custom-text",
-    "custom-range": "./custom-range"
+    "custom-range": "./custom-range",
+    "custom-button": "./custom-button"
   }
 }

--- a/src/calendar/_example/calendar.wxml
+++ b/src/calendar/_example/calendar.wxml
@@ -11,5 +11,6 @@
   <t-demo title="02 自定义" desc="可自由定义想要的风格">
     <custom-text />
     <custom-range />
+    <custom-button />
   </t-demo>
 </view>

--- a/src/calendar/_example/custom-button/index.js
+++ b/src/calendar/_example/custom-button/index.js
@@ -1,22 +1,23 @@
 Component({
   data: {
     visible: false,
+    min: new Date(2022, 0, 2).getTime(),
     note: '',
   },
   methods: {
     handleCalendar() {
       this.setData({ visible: true });
     },
-    handleConfirm(e) {
+    onChange(e) {
       const { value } = e.detail;
+      const [start, end] = value;
       const format = (val) => {
         const date = new Date(val);
-        return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+        return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
       };
 
       this.setData({
-        note: format(value),
-        visible: false,
+        note: `${format(start)} - ${format(end)}`,
       });
     },
   },

--- a/src/calendar/_example/custom-button/index.json
+++ b/src/calendar/_example/custom-button/index.json
@@ -1,0 +1,6 @@
+{
+  "component": true,
+  "usingComponents": {
+    "t-calendar": "tdesign-miniprogram/calendar/calendar"
+  }
+}

--- a/src/calendar/_example/custom-button/index.wxml
+++ b/src/calendar/_example/custom-button/index.wxml
@@ -1,0 +1,2 @@
+<t-calendar type="range" minDate="{{min}}" visible="{{visible}}" confirm-btn="{{null}}" bind:change="onChange" />
+<t-cell arrow title="不显示按钮" bind:tap="handleCalendar" note="{{note}}" />

--- a/src/calendar/_example/custom-button/index.wxss
+++ b/src/calendar/_example/custom-button/index.wxss
@@ -1,0 +1,3 @@
+page {
+  --td-cell-note-font-size: 20rpx;
+}

--- a/src/calendar/calendar.wxml
+++ b/src/calendar/calendar.wxml
@@ -47,7 +47,7 @@
           </view>
         </block>
       </scroll-view>
-      <view class="{{classPrefix}}__footer">
+      <view wx:if="{{confirmBtn != null}}" class="{{classPrefix}}__footer">
         <slot wx:if="{{confirmBtn === 'slot'}}" name="confirmBtn" />
         <block wx:elif="{{confirmBtn}}">
           <!-- <t-button block theme="primary" v-bind="confirmBtn" bind:tap="handleConfirm" /> -->

--- a/src/calendar/props.ts
+++ b/src/calendar/props.ts
@@ -27,11 +27,11 @@ const props: TdCalendarProps = {
   },
   /** 最大可选的日期，不传则默认半年后 */
   maxDate: {
-    type: null,
+    type: Number,
   },
   /** 最小可选的日期，不传则默认今天 */
   minDate: {
-    type: null,
+    type: Number,
   },
   /** 标题，不传默认为“请选择日期” */
   title: {
@@ -45,6 +45,11 @@ const props: TdCalendarProps = {
   },
   /** 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组 */
   value: {
+    type: null,
+    value: null,
+  },
+  /** 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组，非受控属性 */
+  defaultValue: {
     type: null,
   },
   /** 是否显示日历 */

--- a/src/calendar/type.ts
+++ b/src/calendar/type.ts
@@ -36,21 +36,21 @@ export interface TdCalendarProps {
    */
   format?: {
     type: undefined;
-    value?: (day: TDate) => TDate;
+    value?: CalendarFormatType;
   };
   /**
    * 最大可选的日期，不传则默认半年后
    */
   maxDate?: {
     type: NumberConstructor;
-    value?: number | Date;
+    value?: number;
   };
   /**
    * 最小可选的日期，不传则默认今天
    */
   minDate?: {
     type: NumberConstructor;
-    value?: number | Date;
+    value?: number;
   };
   /**
    * 标题，不传默认为“请选择日期”
@@ -62,7 +62,7 @@ export interface TdCalendarProps {
   };
   /**
    * 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择
-   * @default 'single'
+   * @default single
    */
   type?: {
     type: StringConstructor;
@@ -73,7 +73,14 @@ export interface TdCalendarProps {
    */
   value?: {
     type: null;
-    value?: number | Date | TCalendarValue[];
+    value?: number | number[];
+  };
+  /**
+   * 当前选择的日期，不传则默认今天，当 type = multiple 或 range 时传入数组，非受控属性
+   */
+  defaultValue?: {
+    type: null;
+    value?: number | number[];
   };
   /**
    * 是否显示日历
@@ -85,6 +92,8 @@ export interface TdCalendarProps {
   };
 }
 
+export type CalendarFormatType = (day: TDate) => TDate;
+
 export type TDateType = 'selected' | 'disabled' | 'start' | 'centre' | 'end' | '';
 
 export interface TDate {
@@ -95,5 +104,3 @@ export interface TDate {
   prefix?: string;
   suffix?: string;
 }
-
-export type TCalendarValue = number | Date;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1108

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修复 confirm-btn = null 时仍显示按钮的问题


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Calendar): 修复 confirm-btn = null 时仍显示按钮的问题
- feat(Calendar): 新增 change 事件，在不显示确认按钮时使用
- break(Calendar): 事件返回参数改成时间戳，保持和 value 一致

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
