### PR TITLE
feat(grid): support aria

### DIFF
--- a/src/common/src/index.ts
+++ b/src/common/src/index.ts
@@ -2,3 +2,4 @@ export * from './superComponent';
 export * from './flatTool';
 export * from './instantiationDecorator';
 export * from './control';
+export * from './useId';

--- a/src/common/src/useId.ts
+++ b/src/common/src/useId.ts
@@ -1,6 +1,10 @@
+import config from '../config';
+
+const { prefix } = config;
+
 const defaultId = {
-  blur: Math.floor(Math.random() * 100),
+  // blur: Math.floor(Math.random() * 100), 保留 blur 功能，用于混淆 id 避免 id 重复，先不使用，如有必要再添加
   current: 0,
 };
 
-export const useId = (prefix: string): string => `${prefix}-id-${defaultId.blur}-${defaultId.current++}`;
+export const useId = (): string => `${prefix}-id-${defaultId.current++}`;

--- a/src/common/src/useId.ts
+++ b/src/common/src/useId.ts
@@ -1,0 +1,6 @@
+const defaultId = {
+  blur: Math.floor(Math.random() * 100),
+  current: 0,
+};
+
+export const useId = (prefix: string): string => `${prefix}-id-${defaultId.blur}-${defaultId.current++}`;

--- a/src/grid/__test__/__snapshots__/index.test.js.snap
+++ b/src/grid/__test__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`grid :base 1`] = `
           bind:click="handleClick"
         >
           <wx-view
-            ariaLabelledby="item-label"
+            ariaLabelledby="t-id-0"
             ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
@@ -36,7 +36,7 @@ exports[`grid :base 1`] = `
               >
                 <wx-view
                   class="t-grid-item__words t-grid-item__words--vertical"
-                  id="item-label"
+                  id="t-id-0"
                 />
               </wx-view>
             </wx-view>
@@ -44,7 +44,7 @@ exports[`grid :base 1`] = `
         </t-grid-item>
         <t-grid-item>
           <wx-view
-            ariaLabelledby="item-label"
+            ariaLabelledby="t-id-1"
             ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
@@ -62,7 +62,7 @@ exports[`grid :base 1`] = `
               >
                 <wx-view
                   class="t-grid-item__words t-grid-item__words--vertical"
-                  id="item-label"
+                  id="t-id-1"
                 />
               </wx-view>
             </wx-view>

--- a/src/grid/__test__/__snapshots__/index.test.js.snap
+++ b/src/grid/__test__/__snapshots__/index.test.js.snap
@@ -27,7 +27,6 @@ exports[`grid :base 1`] = `
             bind:tap="onClick"
           >
             <wx-view
-              ariaHidden="{{true}}"
               class="t-grid-item__wrapper t-grid-item__wrapper--vertical"
               style="padding-left:4rpx;padding-top:4rpx"
             >
@@ -54,7 +53,6 @@ exports[`grid :base 1`] = `
             bind:tap="onClick"
           >
             <wx-view
-              ariaHidden="{{true}}"
               class="t-grid-item__wrapper t-grid-item__wrapper--vertical"
               style="padding-left:4rpx;padding-top:4rpx"
             >

--- a/src/grid/__test__/__snapshots__/index.test.js.snap
+++ b/src/grid/__test__/__snapshots__/index.test.js.snap
@@ -18,6 +18,8 @@ exports[`grid :base 1`] = `
           bind:click="handleClick"
         >
           <wx-view
+            ariaLabel=""
+            ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
             hoverStayTime="{{200}}"
@@ -25,6 +27,7 @@ exports[`grid :base 1`] = `
             bind:tap="onClick"
           >
             <wx-view
+              ariaHidden="{{true}}"
               class="t-grid-item__wrapper t-grid-item__wrapper--vertical"
               style="padding-left:4rpx;padding-top:4rpx"
             >
@@ -41,6 +44,8 @@ exports[`grid :base 1`] = `
         </t-grid-item>
         <t-grid-item>
           <wx-view
+            ariaLabel=""
+            ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
             hoverStayTime="{{200}}"
@@ -48,6 +53,7 @@ exports[`grid :base 1`] = `
             bind:tap="onClick"
           >
             <wx-view
+              ariaHidden="{{true}}"
               class="t-grid-item__wrapper t-grid-item__wrapper--vertical"
               style="padding-left:4rpx;padding-top:4rpx"
             >

--- a/src/grid/__test__/__snapshots__/index.test.js.snap
+++ b/src/grid/__test__/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`grid :base 1`] = `
           bind:click="handleClick"
         >
           <wx-view
-            ariaLabel=""
+            ariaLabelledby="item-label"
             ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
@@ -37,6 +37,7 @@ exports[`grid :base 1`] = `
               >
                 <wx-view
                   class="t-grid-item__words t-grid-item__words--vertical"
+                  id="item-label"
                 />
               </wx-view>
             </wx-view>
@@ -44,7 +45,7 @@ exports[`grid :base 1`] = `
         </t-grid-item>
         <t-grid-item>
           <wx-view
-            ariaLabel=""
+            ariaLabelledby="item-label"
             ariaRole="button"
             class="t-grid-item t-class"
             hoverClass=""
@@ -63,6 +64,7 @@ exports[`grid :base 1`] = `
               >
                 <wx-view
                   class="t-grid-item__words t-grid-item__words--vertical"
+                  id="item-label"
                 />
               </wx-view>
             </wx-view>

--- a/src/grid/grid-item.ts
+++ b/src/grid/grid-item.ts
@@ -56,7 +56,7 @@ export default class GridItem extends SuperComponent {
   lifetimes = {
     ready() {
       this.setData({
-        labelId: useId(name),
+        labelId: useId(),
       });
     },
   };

--- a/src/grid/grid-item.ts
+++ b/src/grid/grid-item.ts
@@ -1,4 +1,4 @@
-import { SuperComponent, wxComponent, isObject, RelationsOptions } from '../common/src/index';
+import { SuperComponent, wxComponent, isObject, RelationsOptions, useId } from '../common/src/index';
 import config from '../common/config';
 import props from './grid-item-props';
 
@@ -50,6 +50,15 @@ export default class GridItem extends SuperComponent {
     align: 'center',
     layout: 'vertical',
     column: 0,
+    labelId: '',
+  };
+
+  lifetimes = {
+    ready() {
+      this.setData({
+        labelId: useId(name),
+      });
+    },
   };
 
   updateStyle() {

--- a/src/grid/grid-item.wxml
+++ b/src/grid/grid-item.wxml
@@ -14,7 +14,7 @@
   aria-role="{{ariaRole || 'button'}}"
   aria-labelledby="item-label"
 >
-  <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}" aria-hidden>
+  <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}">
     <view
       class="{{_.cls(classPrefix + '__content', [align, layout])}} {{prefix}}-class-content"
       style="{{gridItemContentStyle}}"

--- a/src/grid/grid-item.wxml
+++ b/src/grid/grid-item.wxml
@@ -12,7 +12,7 @@
   hover-stay-time="{{200}}"
   bindtap="onClick"
   aria-role="{{ariaRole || 'button'}}"
-  aria-labelledby="item-label"
+  aria-labelledby="{{labelId}}"
 >
   <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}">
     <view
@@ -55,7 +55,7 @@
           ></t-icon>
         </view>
       </t-badge>
-      <view class="{{_.cls(classPrefix + '__words', [layout])}}" id="item-label">
+      <view class="{{_.cls(classPrefix + '__words', [layout])}}" id="{{labelId}}">
         <view
           wx:if="{{text && text !== 'slot'}}"
           class="{{_.cls(classPrefix + '__text', [util.getImageSize(column), layout])}} {{prefix}}-class-text"

--- a/src/grid/grid-item.wxml
+++ b/src/grid/grid-item.wxml
@@ -11,8 +11,8 @@
   hover-class="{{hover ? classPrefix + '--hover':''}}"
   hover-stay-time="{{200}}"
   bindtap="onClick"
-  aria-label="{{ariaLabel || text}}"
   aria-role="{{ariaRole || 'button'}}"
+  aria-labelledby="item-label"
 >
   <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}" aria-hidden>
     <view
@@ -55,7 +55,7 @@
           ></t-icon>
         </view>
       </t-badge>
-      <view class="{{_.cls(classPrefix + '__words', [layout])}}">
+      <view class="{{_.cls(classPrefix + '__words', [layout])}}" id="item-label">
         <view
           wx:if="{{text && text !== 'slot'}}"
           class="{{_.cls(classPrefix + '__text', [util.getImageSize(column), layout])}} {{prefix}}-class-text"

--- a/src/grid/grid-item.wxml
+++ b/src/grid/grid-item.wxml
@@ -11,8 +11,10 @@
   hover-class="{{hover ? classPrefix + '--hover':''}}"
   hover-stay-time="{{200}}"
   bindtap="onClick"
+  aria-label="{{ariaLabel || text}}"
+  aria-role="{{ariaRole || 'button'}}"
 >
-  <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}">
+  <view class="{{_.cls(classPrefix + '__wrapper', [layout])}}" style="{{gridItemWrapperStyle}}" aria-hidden>
     <view
       class="{{_.cls(classPrefix + '__content', [align, layout])}} {{prefix}}-class-content"
       style="{{gridItemContentStyle}}"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

fix #1025 

### 💡 需求背景和解决方案

1. grid-item 增加 `aria-label` 和 `aria-role` (默认 `button`)

ios 录屏


https://user-images.githubusercontent.com/44194929/205233256-c95d6066-a9e3-4612-b82d-7d14a2913fb7.mov




### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Grid): 无障碍支持


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
