### PR TITLE
feat(cell): 增加无障碍支持

### DIFF
--- a/src/cell/__test__/__snapshots__/demo.test.js.snap
+++ b/src/cell/__test__/__snapshots__/demo.test.js.snap
@@ -81,7 +81,6 @@ exports[`Cell Cell multiple demo works fine 1`] = `
       />
     </t-cell>
     <t-cell
-      arrow="{{true}}"
       description="一段很长很长的内容文字"
       title="单行标题"
     >

--- a/src/cell/__test__/__snapshots__/index.test.js.snap
+++ b/src/cell/__test__/__snapshots__/index.test.js.snap
@@ -6,6 +6,7 @@ exports[`cell :base 1`] = `
     id="cell"
   >
     <wx-view
+      ariaLabel=""
       ariaRole=""
       class="t-class t-cell   t-cell--middle"
       hoverClass="t-cell--hover-class"

--- a/src/cell/_example/multiple/index.wxml
+++ b/src/cell/_example/multiple/index.wxml
@@ -4,7 +4,7 @@
   <t-cell title="单行标题" description="一段很长很长的内容文字" arrow>
     <t-badge count="{{16}}" slot="note" />
   </t-cell>
-  <t-cell title="单行标题" description="一段很长很长的内容文字" arrow>
+  <t-cell title="单行标题" description="一段很长很长的内容文字">
     <t-switch defaultValue="{{true}}" slot="note" />
   </t-cell>
   <t-cell title="单行标题" description="一段很长很长的内容文字" note="辅助信息" arrow> </t-cell>

--- a/src/cell/cell.wxml
+++ b/src/cell/cell.wxml
@@ -4,7 +4,8 @@
   hover-class="{{classPrefix}}--hover-class"
   hover-stay-time="70"
   bind:tap="onClick"
-  aria-role="{{ariaRole}}"
+  aria-role="{{ariaRole || (arrow ? 'button' : '')}}"
+  aria-label="{{ariaLabel}}"
 >
   <view class="{{classPrefix}}__left {{prefix}}-class-left">
     <t-icon wx:if="{{ leftIcon }}" name="{{leftIcon}}" class="{{classPrefix}}__left-icon {{prefix}}-class-left-icon" />

--- a/src/collapse/__test__/__snapshots__/index.test.js.snap
+++ b/src/collapse/__test__/__snapshots__/index.test.js.snap
@@ -32,6 +32,7 @@ exports[`collapse :base 1`] = `
               tClassTitle="class-title "
             >
               <wx-view
+                ariaLabel=""
                 ariaRole=""
                 class="t-class t-cell   t-cell--middle"
                 hoverClass="t-cell--hover-class"
@@ -119,6 +120,7 @@ exports[`collapse :base 1`] = `
               tClassTitle="class-title "
             >
               <wx-view
+                ariaLabel=""
                 ariaRole=""
                 class="t-class t-cell   t-cell--middle"
                 hoverClass="t-cell--hover-class"
@@ -213,6 +215,7 @@ exports[`collapse :base 1`] = `
               tClassTitle="class-title "
             >
               <wx-view
+                ariaLabel=""
                 ariaRole=""
                 class="t-class t-cell   t-cell--middle"
                 hoverClass="t-cell--hover-class"
@@ -298,6 +301,7 @@ exports[`collapse :base 1`] = `
               tClassTitle="class-title "
             >
               <wx-view
+                ariaLabel=""
                 ariaRole=""
                 class="t-class t-cell   t-cell--middle"
                 hoverClass="t-cell--hover-class"
@@ -396,6 +400,7 @@ exports[`collapse :defaultExpandAll 1`] = `
             tClassTitle="class-title "
           >
             <wx-view
+              ariaLabel=""
               ariaRole=""
               class="t-class t-cell   t-cell--middle"
               hoverClass="t-cell--hover-class"
@@ -481,6 +486,7 @@ exports[`collapse :defaultExpandAll 1`] = `
             tClassTitle="class-title "
           >
             <wx-view
+              ariaLabel=""
               ariaRole=""
               class="t-class t-cell   t-cell--middle"
               hoverClass="t-cell--hover-class"
@@ -581,6 +587,7 @@ exports[`collapse :disabled 1`] = `
             tClassTitle="class-title "
           >
             <wx-view
+              ariaLabel=""
               ariaRole=""
               class="t-class t-cell   t-cell--middle"
               hoverClass="t-cell--hover-class"
@@ -668,6 +675,7 @@ exports[`collapse :disabled 1`] = `
             tClassTitle="class-title "
           >
             <wx-view
+              ariaLabel=""
               ariaRole=""
               class="t-class t-cell   t-cell--middle"
               hoverClass="t-cell--hover-class"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1031 

### 💡 需求背景和解决方案
- **cell** 每行焦点分散问题，每行应统一获得焦点 => **cell** 组件默认设置`aria-role=button`
- ~~**cell** 右侧若是开关则朗读相应的 **role** => **cell** 组件向上暴露的 **aria-role** 属性、**aria-checked** 属性~~ 
cell 和 switch 组件一起使用时，暂不考虑行焦点问题 @syxysszyw 
- 每行可自定义朗读内容 => **cell** 组件向上暴露的 **aria-label** 属性

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Cell): 支持无障碍访问

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


### 👇 todos
- [x] 添加录屏示例
- [ ] 更新 test-snapshots: cell, collapse

### 录屏链接🔗
https://share.weiyun.com/V7CYP1DA