### PR TITLE
feat(collapse): 无障碍支持

### DIFF
--- a/src/collapse/__test__/__snapshots__/index.test.js.snap
+++ b/src/collapse/__test__/__snapshots__/index.test.js.snap
@@ -17,63 +17,70 @@ exports[`collapse :base 1`] = `
           class="t-collapse-panel t-class"
           style=""
         >
-          <t-cell
+          <wx-view
+            ariaDisabled="{{false}}"
+            ariaExpanded="{{true}}"
+            ariaRole="button"
             class="t-collapse-panel__title"
-            tClass="t-collapse-panel__header t-class-header"
-            tClassHover="class-header-hover"
-            tClassNote="class-note "
-            tClassRightIcon="class-right-icon "
-            tClassTitle="class-title "
-            bind:click="onClick"
+            bind:tap="onClick"
           >
-            <wx-view
-              class="t-class t-cell   t-cell--middle"
-              hoverClass="t-cell--hover-class"
-              hoverStayTime="70"
-              style=""
-              bind:tap="onClick"
+            <t-cell
+              tClass="t-collapse-panel__header t-class-header"
+              tClassHover="class-header-hover"
+              tClassNote="class-note "
+              tClassRightIcon="class-right-icon "
+              tClassTitle="class-title "
             >
               <wx-view
-                class="t-cell__left t-class-left"
-              />
-              <wx-view
-                class="t-cell__title t-class-title"
+                class="t-class t-cell   t-cell--middle"
+                hoverClass="t-cell--hover-class"
+                hoverStayTime="70"
+                style=""
+                bind:tap="onClick"
               >
                 <wx-view
-                  class="t-cell__title-text"
-                >
-                   first 
-                </wx-view>
-                <wx-view
-                  class="t-cell__description t-class-description"
+                  class="t-cell__left t-class-left"
                 />
-              </wx-view>
-              <wx-view
-                class="t-cell__note t-class-note"
-              />
-              <wx-view
-                class="t-cell__right t-class-right"
-              >
-                <t-icon
-                  class="t-cell__right-icon t-class-right-icon"
+                <wx-view
+                  class="t-cell__title t-class-title"
                 >
                   <wx-view
-                    ariaHidden="{{false}}"
-                    ariaLabel=""
-                    ariaRole=""
-                    class="t-icon t-class"
-                    style=""
-                    bind:tap="onTap"
+                    class="t-cell__title-text"
                   >
-                    <wx-label
-                      class="t-icon-chevron-up t-icon-base"
-                    />
+                     first 
                   </wx-view>
-                </t-icon>
+                  <wx-view
+                    class="t-cell__description t-class-description"
+                  />
+                </wx-view>
+                <wx-view
+                  class="t-cell__note t-class-note"
+                />
+                <wx-view
+                  class="t-cell__right t-class-right"
+                >
+                  <t-icon
+                    class="t-cell__right-icon t-class-right-icon"
+                  >
+                    <wx-view
+                      ariaHidden="{{false}}"
+                      ariaLabel=""
+                      ariaRole=""
+                      class="t-icon t-class"
+                      style=""
+                      bind:tap="onTap"
+                    >
+                      <wx-label
+                        class="t-icon-chevron-up t-icon-base"
+                      />
+                    </wx-view>
+                  </t-icon>
+                </wx-view>
               </wx-view>
-            </wx-view>
-          </t-cell>
+            </t-cell>
+          </wx-view>
           <wx-view
+            ariaHidden=""
             class="t-collapse-panel__wrapper"
             style="height: 0;"
             bind:transitionend="onTransitionEnd"
@@ -96,63 +103,70 @@ exports[`collapse :base 1`] = `
           class="t-collapse-panel t-class"
           style=""
         >
-          <t-cell
+          <wx-view
+            ariaDisabled="{{false}}"
+            ariaExpanded="{{false}}"
+            ariaRole="button"
             class="t-collapse-panel__title"
-            tClass="t-collapse-panel__header t-class-header"
-            tClassHover="class-header-hover"
-            tClassNote="class-note "
-            tClassRightIcon="class-right-icon "
-            tClassTitle="class-title "
-            bind:click="onClick"
+            bind:tap="onClick"
           >
-            <wx-view
-              class="t-class t-cell   t-cell--middle"
-              hoverClass="t-cell--hover-class"
-              hoverStayTime="70"
-              style=""
-              bind:tap="onClick"
+            <t-cell
+              tClass="t-collapse-panel__header t-class-header"
+              tClassHover="class-header-hover"
+              tClassNote="class-note "
+              tClassRightIcon="class-right-icon "
+              tClassTitle="class-title "
             >
               <wx-view
-                class="t-cell__left t-class-left"
-              />
-              <wx-view
-                class="t-cell__title t-class-title"
+                class="t-class t-cell   t-cell--middle"
+                hoverClass="t-cell--hover-class"
+                hoverStayTime="70"
+                style=""
+                bind:tap="onClick"
               >
                 <wx-view
-                  class="t-cell__title-text"
-                >
-                   second 
-                </wx-view>
-                <wx-view
-                  class="t-cell__description t-class-description"
+                  class="t-cell__left t-class-left"
                 />
-              </wx-view>
-              <wx-view
-                class="t-cell__note t-class-note"
-              />
-              <wx-view
-                class="t-cell__right t-class-right"
-              >
-                <t-icon
-                  class="t-cell__right-icon t-class-right-icon"
+                <wx-view
+                  class="t-cell__title t-class-title"
                 >
                   <wx-view
-                    ariaHidden="{{false}}"
-                    ariaLabel=""
-                    ariaRole=""
-                    class="t-icon t-class"
-                    style=""
-                    bind:tap="onTap"
+                    class="t-cell__title-text"
                   >
-                    <wx-label
-                      class="t-icon-chevron-down t-icon-base"
-                    />
+                     second 
                   </wx-view>
-                </t-icon>
+                  <wx-view
+                    class="t-cell__description t-class-description"
+                  />
+                </wx-view>
+                <wx-view
+                  class="t-cell__note t-class-note"
+                />
+                <wx-view
+                  class="t-cell__right t-class-right"
+                >
+                  <t-icon
+                    class="t-cell__right-icon t-class-right-icon"
+                  >
+                    <wx-view
+                      ariaHidden="{{false}}"
+                      ariaLabel=""
+                      ariaRole=""
+                      class="t-icon t-class"
+                      style=""
+                      bind:tap="onTap"
+                    >
+                      <wx-label
+                        class="t-icon-chevron-down t-icon-base"
+                      />
+                    </wx-view>
+                  </t-icon>
+                </wx-view>
               </wx-view>
-            </wx-view>
-          </t-cell>
+            </t-cell>
+          </wx-view>
           <wx-view
+            ariaHidden="{{true}}"
             class="t-collapse-panel__wrapper"
             style="height: 0;"
             bind:transitionend="onTransitionEnd"
@@ -182,63 +196,70 @@ exports[`collapse :base 1`] = `
           class="t-collapse-panel t-class"
           style=""
         >
-          <t-cell
+          <wx-view
+            ariaDisabled="{{false}}"
+            ariaExpanded="{{false}}"
+            ariaRole="button"
             class="t-collapse-panel__title"
-            tClass="t-collapse-panel__header t-class-header"
-            tClassHover="class-header-hover"
-            tClassNote="class-note "
-            tClassRightIcon="class-right-icon "
-            tClassTitle="class-title "
-            bind:click="onClick"
+            bind:tap="onClick"
           >
-            <wx-view
-              class="t-class t-cell   t-cell--middle"
-              hoverClass="t-cell--hover-class"
-              hoverStayTime="70"
-              style=""
-              bind:tap="onClick"
+            <t-cell
+              tClass="t-collapse-panel__header t-class-header"
+              tClassHover="class-header-hover"
+              tClassNote="class-note "
+              tClassRightIcon="class-right-icon "
+              tClassTitle="class-title "
             >
               <wx-view
-                class="t-cell__left t-class-left"
-              />
-              <wx-view
-                class="t-cell__title t-class-title"
+                class="t-class t-cell   t-cell--middle"
+                hoverClass="t-cell--hover-class"
+                hoverStayTime="70"
+                style=""
+                bind:tap="onClick"
               >
                 <wx-view
-                  class="t-cell__title-text"
-                >
-                   first 
-                </wx-view>
-                <wx-view
-                  class="t-cell__description t-class-description"
+                  class="t-cell__left t-class-left"
                 />
-              </wx-view>
-              <wx-view
-                class="t-cell__note t-class-note"
-              />
-              <wx-view
-                class="t-cell__right t-class-right"
-              >
-                <t-icon
-                  class="t-cell__right-icon t-class-right-icon"
+                <wx-view
+                  class="t-cell__title t-class-title"
                 >
                   <wx-view
-                    ariaHidden="{{false}}"
-                    ariaLabel=""
-                    ariaRole=""
-                    class="t-icon t-class"
-                    style=""
-                    bind:tap="onTap"
+                    class="t-cell__title-text"
                   >
-                    <wx-label
-                      class="t-icon-chevron-down t-icon-base"
-                    />
+                     first 
                   </wx-view>
-                </t-icon>
+                  <wx-view
+                    class="t-cell__description t-class-description"
+                  />
+                </wx-view>
+                <wx-view
+                  class="t-cell__note t-class-note"
+                />
+                <wx-view
+                  class="t-cell__right t-class-right"
+                >
+                  <t-icon
+                    class="t-cell__right-icon t-class-right-icon"
+                  >
+                    <wx-view
+                      ariaHidden="{{false}}"
+                      ariaLabel=""
+                      ariaRole=""
+                      class="t-icon t-class"
+                      style=""
+                      bind:tap="onTap"
+                    >
+                      <wx-label
+                        class="t-icon-chevron-down t-icon-base"
+                      />
+                    </wx-view>
+                  </t-icon>
+                </wx-view>
               </wx-view>
-            </wx-view>
-          </t-cell>
+            </t-cell>
+          </wx-view>
           <wx-view
+            ariaHidden="{{true}}"
             class="t-collapse-panel__wrapper"
             style="height: 0;"
             bind:transitionend="onTransitionEnd"
@@ -259,63 +280,70 @@ exports[`collapse :base 1`] = `
           class="t-collapse-panel t-class"
           style=""
         >
-          <t-cell
+          <wx-view
+            ariaDisabled="{{false}}"
+            ariaExpanded="{{true}}"
+            ariaRole="button"
             class="t-collapse-panel__title"
-            tClass="t-collapse-panel__header t-class-header"
-            tClassHover="class-header-hover"
-            tClassNote="class-note "
-            tClassRightIcon="class-right-icon "
-            tClassTitle="class-title "
-            bind:click="onClick"
+            bind:tap="onClick"
           >
-            <wx-view
-              class="t-class t-cell   t-cell--middle"
-              hoverClass="t-cell--hover-class"
-              hoverStayTime="70"
-              style=""
-              bind:tap="onClick"
+            <t-cell
+              tClass="t-collapse-panel__header t-class-header"
+              tClassHover="class-header-hover"
+              tClassNote="class-note "
+              tClassRightIcon="class-right-icon "
+              tClassTitle="class-title "
             >
               <wx-view
-                class="t-cell__left t-class-left"
-              />
-              <wx-view
-                class="t-cell__title t-class-title"
+                class="t-class t-cell   t-cell--middle"
+                hoverClass="t-cell--hover-class"
+                hoverStayTime="70"
+                style=""
+                bind:tap="onClick"
               >
                 <wx-view
-                  class="t-cell__title-text"
-                >
-                   second 
-                </wx-view>
-                <wx-view
-                  class="t-cell__description t-class-description"
+                  class="t-cell__left t-class-left"
                 />
-              </wx-view>
-              <wx-view
-                class="t-cell__note t-class-note"
-              />
-              <wx-view
-                class="t-cell__right t-class-right"
-              >
-                <t-icon
-                  class="t-cell__right-icon t-class-right-icon"
+                <wx-view
+                  class="t-cell__title t-class-title"
                 >
                   <wx-view
-                    ariaHidden="{{false}}"
-                    ariaLabel=""
-                    ariaRole=""
-                    class="t-icon t-class"
-                    style=""
-                    bind:tap="onTap"
+                    class="t-cell__title-text"
                   >
-                    <wx-label
-                      class="t-icon-chevron-up t-icon-base"
-                    />
+                     second 
                   </wx-view>
-                </t-icon>
+                  <wx-view
+                    class="t-cell__description t-class-description"
+                  />
+                </wx-view>
+                <wx-view
+                  class="t-cell__note t-class-note"
+                />
+                <wx-view
+                  class="t-cell__right t-class-right"
+                >
+                  <t-icon
+                    class="t-cell__right-icon t-class-right-icon"
+                  >
+                    <wx-view
+                      ariaHidden="{{false}}"
+                      ariaLabel=""
+                      ariaRole=""
+                      class="t-icon t-class"
+                      style=""
+                      bind:tap="onTap"
+                    >
+                      <wx-label
+                        class="t-icon-chevron-up t-icon-base"
+                      />
+                    </wx-view>
+                  </t-icon>
+                </wx-view>
               </wx-view>
-            </wx-view>
-          </t-cell>
+            </t-cell>
+          </wx-view>
           <wx-view
+            ariaHidden=""
             class="t-collapse-panel__wrapper"
             style="height: 0;"
             bind:transitionend="onTransitionEnd"
@@ -349,63 +377,70 @@ exports[`collapse :defaultExpandAll 1`] = `
         class="t-collapse-panel t-class"
         style=""
       >
-        <t-cell
+        <wx-view
+          ariaDisabled="{{false}}"
+          ariaExpanded="{{false}}"
+          ariaRole="button"
           class="t-collapse-panel__title"
-          tClass="t-collapse-panel__header t-class-header"
-          tClassHover="class-header-hover"
-          tClassNote="class-note "
-          tClassRightIcon="class-right-icon "
-          tClassTitle="class-title "
-          bind:click="onClick"
+          bind:tap="onClick"
         >
-          <wx-view
-            class="t-class t-cell   t-cell--middle"
-            hoverClass="t-cell--hover-class"
-            hoverStayTime="70"
-            style=""
-            bind:tap="onClick"
+          <t-cell
+            tClass="t-collapse-panel__header t-class-header"
+            tClassHover="class-header-hover"
+            tClassNote="class-note "
+            tClassRightIcon="class-right-icon "
+            tClassTitle="class-title "
           >
             <wx-view
-              class="t-cell__left t-class-left"
-            />
-            <wx-view
-              class="t-cell__title t-class-title"
+              class="t-class t-cell   t-cell--middle"
+              hoverClass="t-cell--hover-class"
+              hoverStayTime="70"
+              style=""
+              bind:tap="onClick"
             >
               <wx-view
-                class="t-cell__title-text"
-              >
-                 first 
-              </wx-view>
-              <wx-view
-                class="t-cell__description t-class-description"
+                class="t-cell__left t-class-left"
               />
-            </wx-view>
-            <wx-view
-              class="t-cell__note t-class-note"
-            />
-            <wx-view
-              class="t-cell__right t-class-right"
-            >
-              <t-icon
-                class="t-cell__right-icon t-class-right-icon"
+              <wx-view
+                class="t-cell__title t-class-title"
               >
                 <wx-view
-                  ariaHidden="{{false}}"
-                  ariaLabel=""
-                  ariaRole=""
-                  class="t-icon t-class"
-                  style=""
-                  bind:tap="onTap"
+                  class="t-cell__title-text"
                 >
-                  <wx-label
-                    class="t-icon-chevron-down t-icon-base"
-                  />
+                   first 
                 </wx-view>
-              </t-icon>
+                <wx-view
+                  class="t-cell__description t-class-description"
+                />
+              </wx-view>
+              <wx-view
+                class="t-cell__note t-class-note"
+              />
+              <wx-view
+                class="t-cell__right t-class-right"
+              >
+                <t-icon
+                  class="t-cell__right-icon t-class-right-icon"
+                >
+                  <wx-view
+                    ariaHidden="{{false}}"
+                    ariaLabel=""
+                    ariaRole=""
+                    class="t-icon t-class"
+                    style=""
+                    bind:tap="onTap"
+                  >
+                    <wx-label
+                      class="t-icon-chevron-down t-icon-base"
+                    />
+                  </wx-view>
+                </t-icon>
+              </wx-view>
             </wx-view>
-          </wx-view>
-        </t-cell>
+          </t-cell>
+        </wx-view>
         <wx-view
+          ariaHidden="{{true}}"
           class="t-collapse-panel__wrapper"
           style="height: 0;"
           bind:transitionend="onTransitionEnd"
@@ -426,63 +461,70 @@ exports[`collapse :defaultExpandAll 1`] = `
         class="t-collapse-panel t-class"
         style=""
       >
-        <t-cell
+        <wx-view
+          ariaDisabled="{{false}}"
+          ariaExpanded="{{true}}"
+          ariaRole="button"
           class="t-collapse-panel__title"
-          tClass="t-collapse-panel__header t-class-header"
-          tClassHover="class-header-hover"
-          tClassNote="class-note "
-          tClassRightIcon="class-right-icon "
-          tClassTitle="class-title "
-          bind:click="onClick"
+          bind:tap="onClick"
         >
-          <wx-view
-            class="t-class t-cell   t-cell--middle"
-            hoverClass="t-cell--hover-class"
-            hoverStayTime="70"
-            style=""
-            bind:tap="onClick"
+          <t-cell
+            tClass="t-collapse-panel__header t-class-header"
+            tClassHover="class-header-hover"
+            tClassNote="class-note "
+            tClassRightIcon="class-right-icon "
+            tClassTitle="class-title "
           >
             <wx-view
-              class="t-cell__left t-class-left"
-            />
-            <wx-view
-              class="t-cell__title t-class-title"
+              class="t-class t-cell   t-cell--middle"
+              hoverClass="t-cell--hover-class"
+              hoverStayTime="70"
+              style=""
+              bind:tap="onClick"
             >
               <wx-view
-                class="t-cell__title-text"
-              >
-                 second 
-              </wx-view>
-              <wx-view
-                class="t-cell__description t-class-description"
+                class="t-cell__left t-class-left"
               />
-            </wx-view>
-            <wx-view
-              class="t-cell__note t-class-note"
-            />
-            <wx-view
-              class="t-cell__right t-class-right"
-            >
-              <t-icon
-                class="t-cell__right-icon t-class-right-icon"
+              <wx-view
+                class="t-cell__title t-class-title"
               >
                 <wx-view
-                  ariaHidden="{{false}}"
-                  ariaLabel=""
-                  ariaRole=""
-                  class="t-icon t-class"
-                  style=""
-                  bind:tap="onTap"
+                  class="t-cell__title-text"
                 >
-                  <wx-label
-                    class="t-icon-chevron-up t-icon-base"
-                  />
+                   second 
                 </wx-view>
-              </t-icon>
+                <wx-view
+                  class="t-cell__description t-class-description"
+                />
+              </wx-view>
+              <wx-view
+                class="t-cell__note t-class-note"
+              />
+              <wx-view
+                class="t-cell__right t-class-right"
+              >
+                <t-icon
+                  class="t-cell__right-icon t-class-right-icon"
+                >
+                  <wx-view
+                    ariaHidden="{{false}}"
+                    ariaLabel=""
+                    ariaRole=""
+                    class="t-icon t-class"
+                    style=""
+                    bind:tap="onTap"
+                  >
+                    <wx-label
+                      class="t-icon-chevron-up t-icon-base"
+                    />
+                  </wx-view>
+                </t-icon>
+              </wx-view>
             </wx-view>
-          </wx-view>
-        </t-cell>
+          </t-cell>
+        </wx-view>
         <wx-view
+          ariaHidden=""
           class="t-collapse-panel__wrapper"
           style="height: 0;"
           bind:transitionend="onTransitionEnd"
@@ -518,63 +560,70 @@ exports[`collapse :disabled 1`] = `
         class="t-collapse-panel t-class"
         style=""
       >
-        <t-cell
+        <wx-view
+          ariaDisabled="{{false}}"
+          ariaExpanded="{{true}}"
+          ariaRole="button"
           class="t-collapse-panel__title"
-          tClass="t-collapse-panel__header t-class-header"
-          tClassHover="class-header-hover"
-          tClassNote="class-note "
-          tClassRightIcon="class-right-icon "
-          tClassTitle="class-title "
-          bind:click="onClick"
+          bind:tap="onClick"
         >
-          <wx-view
-            class="t-class t-cell   t-cell--middle"
-            hoverClass="t-cell--hover-class"
-            hoverStayTime="70"
-            style=""
-            bind:tap="onClick"
+          <t-cell
+            tClass="t-collapse-panel__header t-class-header"
+            tClassHover="class-header-hover"
+            tClassNote="class-note "
+            tClassRightIcon="class-right-icon "
+            tClassTitle="class-title "
           >
             <wx-view
-              class="t-cell__left t-class-left"
-            />
-            <wx-view
-              class="t-cell__title t-class-title"
+              class="t-class t-cell   t-cell--middle"
+              hoverClass="t-cell--hover-class"
+              hoverStayTime="70"
+              style=""
+              bind:tap="onClick"
             >
               <wx-view
-                class="t-cell__title-text"
-              >
-                 first 
-              </wx-view>
-              <wx-view
-                class="t-cell__description t-class-description"
+                class="t-cell__left t-class-left"
               />
-            </wx-view>
-            <wx-view
-              class="t-cell__note t-class-note"
-            />
-            <wx-view
-              class="t-cell__right t-class-right"
-            >
-              <t-icon
-                class="t-cell__right-icon t-class-right-icon"
+              <wx-view
+                class="t-cell__title t-class-title"
               >
                 <wx-view
-                  ariaHidden="{{false}}"
-                  ariaLabel=""
-                  ariaRole=""
-                  class="t-icon t-class"
-                  style=""
-                  bind:tap="onTap"
+                  class="t-cell__title-text"
                 >
-                  <wx-label
-                    class="t-icon-chevron-up t-icon-base"
-                  />
+                   first 
                 </wx-view>
-              </t-icon>
+                <wx-view
+                  class="t-cell__description t-class-description"
+                />
+              </wx-view>
+              <wx-view
+                class="t-cell__note t-class-note"
+              />
+              <wx-view
+                class="t-cell__right t-class-right"
+              >
+                <t-icon
+                  class="t-cell__right-icon t-class-right-icon"
+                >
+                  <wx-view
+                    ariaHidden="{{false}}"
+                    ariaLabel=""
+                    ariaRole=""
+                    class="t-icon t-class"
+                    style=""
+                    bind:tap="onTap"
+                  >
+                    <wx-label
+                      class="t-icon-chevron-up t-icon-base"
+                    />
+                  </wx-view>
+                </t-icon>
+              </wx-view>
             </wx-view>
-          </wx-view>
-        </t-cell>
+          </t-cell>
+        </wx-view>
         <wx-view
+          ariaHidden=""
           class="t-collapse-panel__wrapper"
           style="height: auto;"
           bind:transitionend="onTransitionEnd"
@@ -597,63 +646,70 @@ exports[`collapse :disabled 1`] = `
         class="t-collapse-panel t-class"
         style=""
       >
-        <t-cell
+        <wx-view
+          ariaDisabled="{{false}}"
+          ariaExpanded="{{false}}"
+          ariaRole="button"
           class="t-collapse-panel__title"
-          tClass="t-collapse-panel__header t-class-header"
-          tClassHover="class-header-hover"
-          tClassNote="class-note "
-          tClassRightIcon="class-right-icon "
-          tClassTitle="class-title "
-          bind:click="onClick"
+          bind:tap="onClick"
         >
-          <wx-view
-            class="t-class t-cell   t-cell--middle"
-            hoverClass="t-cell--hover-class"
-            hoverStayTime="70"
-            style=""
-            bind:tap="onClick"
+          <t-cell
+            tClass="t-collapse-panel__header t-class-header"
+            tClassHover="class-header-hover"
+            tClassNote="class-note "
+            tClassRightIcon="class-right-icon "
+            tClassTitle="class-title "
           >
             <wx-view
-              class="t-cell__left t-class-left"
-            />
-            <wx-view
-              class="t-cell__title t-class-title"
+              class="t-class t-cell   t-cell--middle"
+              hoverClass="t-cell--hover-class"
+              hoverStayTime="70"
+              style=""
+              bind:tap="onClick"
             >
               <wx-view
-                class="t-cell__title-text"
-              >
-                 second 
-              </wx-view>
-              <wx-view
-                class="t-cell__description t-class-description"
+                class="t-cell__left t-class-left"
               />
-            </wx-view>
-            <wx-view
-              class="t-cell__note t-class-note"
-            />
-            <wx-view
-              class="t-cell__right t-class-right"
-            >
-              <t-icon
-                class="t-cell__right-icon t-class-right-icon"
+              <wx-view
+                class="t-cell__title t-class-title"
               >
                 <wx-view
-                  ariaHidden="{{false}}"
-                  ariaLabel=""
-                  ariaRole=""
-                  class="t-icon t-class"
-                  style=""
-                  bind:tap="onTap"
+                  class="t-cell__title-text"
                 >
-                  <wx-label
-                    class="t-icon-chevron-down t-icon-base"
-                  />
+                   second 
                 </wx-view>
-              </t-icon>
+                <wx-view
+                  class="t-cell__description t-class-description"
+                />
+              </wx-view>
+              <wx-view
+                class="t-cell__note t-class-note"
+              />
+              <wx-view
+                class="t-cell__right t-class-right"
+              >
+                <t-icon
+                  class="t-cell__right-icon t-class-right-icon"
+                >
+                  <wx-view
+                    ariaHidden="{{false}}"
+                    ariaLabel=""
+                    ariaRole=""
+                    class="t-icon t-class"
+                    style=""
+                    bind:tap="onTap"
+                  >
+                    <wx-label
+                      class="t-icon-chevron-down t-icon-base"
+                    />
+                  </wx-view>
+                </t-icon>
+              </wx-view>
             </wx-view>
-          </wx-view>
-        </t-cell>
+          </t-cell>
+        </wx-view>
         <wx-view
+          ariaHidden="{{true}}"
           class="t-collapse-panel__wrapper"
           style="height: 0;"
           bind:transitionend="onTransitionEnd"

--- a/src/collapse/__test__/index.test.js
+++ b/src/collapse/__test__/index.test.js
@@ -19,14 +19,14 @@ describe('collapse', () => {
     const $second = comp.querySelector('#second >>> .t-collapse-panel__title');
     const $transitionWrapper = comp.querySelector('#second >>> .t-collapse-panel__wrapper');
 
-    $second.dispatchEvent('click');
+    $second.dispatchEvent('tap');
     $transitionWrapper.dispatchEvent('transitionend');
 
     await simulate.sleep();
 
     expect($base.instance.data.value.includes(1)).toBeTruthy();
 
-    $second.dispatchEvent('click');
+    $second.dispatchEvent('tap');
 
     await simulate.sleep();
 
@@ -37,7 +37,7 @@ describe('collapse', () => {
 
     expect($base.instance.data.value.includes(0)).toBeTruthy();
 
-    $second.dispatchEvent('click');
+    $second.dispatchEvent('tap');
 
     await simulate.sleep();
 

--- a/src/collapse/collapse-panel.wxml
+++ b/src/collapse/collapse-panel.wxml
@@ -1,24 +1,35 @@
 <wxs src="../common/utils.wxs" module="utils" />
 
 <view style="{{ customStyle }}" class="{{classPrefix}} {{prefix}}-class">
-  <t-cell
-    title="{{header}}"
-    note="{{headerRightContent}}"
-    bordered
-    right-icon="{{ ultimateExpandIcon ? (expanded ? 'chevron-up' : 'chevron-down') : '' }}"
+  <view
     class="{{classPrefix}}__title"
-    t-class="{{classPrefix}}__header {{prefix}}-class-header"
-    t-class-title="class-title {{ultimateDisabled ? 'class-title--disabled' : ''}}"
-    t-class-note="class-note {{ultimateDisabled ? 'class-note--disabled' : ''}}"
-    t-class-right-icon="class-right-icon {{ultimateDisabled ? 'class-right-icon--disabled' : ''}}"
-    t-class-hover="class-header-hover"
-    bind:click="onClick"
+    aria-role="button"
+    aria-expanded="{{expanded}}"
+    aria-disabled="{{ultimateDisabled}}"
+    bind:tap="onClick"
   >
-    <slot name="header" slot="title" />
-    <slot name="header-right-content" slot="note" />
-    <slot name="expand-icon" slot="right-icon" />
-  </t-cell>
-  <view class="{{classPrefix}}__wrapper" style="height: {{contentHeight}};" bind:transitionend="onTransitionEnd">
+    <t-cell
+      title="{{header}}"
+      note="{{headerRightContent}}"
+      bordered
+      right-icon="{{ ultimateExpandIcon ? (expanded ? 'chevron-up' : 'chevron-down') : '' }}"
+      t-class="{{classPrefix}}__header {{prefix}}-class-header"
+      t-class-title="class-title {{ultimateDisabled ? 'class-title--disabled' : ''}}"
+      t-class-note="class-note {{ultimateDisabled ? 'class-note--disabled' : ''}}"
+      t-class-right-icon="class-right-icon {{ultimateDisabled ? 'class-right-icon--disabled' : ''}}"
+      t-class-hover="class-header-hover"
+    >
+      <slot name="header" slot="title" />
+      <slot name="header-right-content" slot="note" />
+      <slot name="expand-icon" slot="right-icon" />
+    </t-cell>
+  </view>
+  <view
+    class="{{classPrefix}}__wrapper"
+    style="height: {{contentHeight}};"
+    aria-hidden="{{expanded ? '' : true}}"
+    bind:transitionend="onTransitionEnd"
+  >
     <view
       class="{{classPrefix}}__content {{classPrefix}}__content--{{expanded ? 'active' : ''}} {{prefix}}-class-content"
     >


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fix #1055

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- cell 的 a11y 不确定合入时间，因此先在 header 外层包裹一个 view 元素，增加 bind:tap 和 aria 属性
- wrapper 增加 aria-hidden 属性

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Collapse): 支持无障碍访问

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 录屏

iOS:

https://user-images.githubusercontent.com/5051221/207517871-55fbe6f3-9d4c-4ee6-b2ef-6fee8bcd2214.mp4

Android:

https://user-images.githubusercontent.com/5051221/207523110-d874fc5b-ee41-4ab1-b47b-b593848ef7bd.mp4

- Android 录屏第一次点击 collapse 后，焦点跳到了“网页视图”，可能是华为读屏模式的问题，试了下 weui 小程序也会有同样的问题。