### PR TITLE
feat(dropdown): dropdown-menu无障碍支持

### DIFF
--- a/src/checkbox/checkbox.less
+++ b/src/checkbox/checkbox.less
@@ -27,6 +27,9 @@
   font-size: @checkbox-font-size;
   position: relative;
   background: @checkbox-bg-color;
+  &:focus {
+    outline: 0;
+  }
 
   &--block {
     display: flex;

--- a/src/checkbox/checkbox.wxml
+++ b/src/checkbox/checkbox.wxml
@@ -6,6 +6,7 @@
   aria-role="checkbox"
   aria-checked="{{checked ? (indeterminate ? 'mixed' : true) : false}}"
   aria-disabled="{{disabled ? true : false}}"
+  tabindex="{{tabindex}}"
 >
   <view
     wx:if="{{theme == 'default'}}"

--- a/src/dropdown-menu/dropdown-item.wxml
+++ b/src/dropdown-menu/dropdown-item.wxml
@@ -27,18 +27,19 @@
         value="{{value}}"
         bind:change="handleRadioChange"
       >
-        <block wx:for="{{options}}" wx:key="index" tabindex="0">
-          <t-radio
-            class="{{classPrefix}}__radio-item {{prefix}}-class-column-item"
-            icon="line"
-            align="right"
-            t-class="radio"
-            t-class-label="{{prefix}}-class-column-item-label"
-            value="{{item[valueAlias]}}"
-            label="{{item[labelAlias]}}"
-            disabled="{{item.disabled}}"
-          ></t-radio>
-        </block>
+        <t-radio
+          wx:for="{{options}}"
+          wx:key="index"
+          tabindex="0"
+          class="{{classPrefix}}__radio-item {{prefix}}-class-column-item"
+          icon="line"
+          align="right"
+          t-class="radio"
+          t-class-label="{{prefix}}-class-column-item-label"
+          value="{{item[valueAlias]}}"
+          label="{{item[labelAlias]}}"
+          disabled="{{item.disabled}}"
+        ></t-radio>
       </t-radio-group>
       <!-- 多选列表 -->
       <t-checkbox-group
@@ -49,8 +50,9 @@
         value="{{value}}"
         bind:change="handleRadioChange"
       >
-        <block wx:for="{{options}}" wx:key="index" tabindex="0">
+        <block wx:for="{{options}}" wx:key="index">
           <t-checkbox
+            tabindex="0"
             class="{{classPrefix}}__checkbox-item {{prefix}}-class-column-item"
             theme="tag"
             value="{{item[valueAlias]}}"

--- a/src/dropdown-menu/dropdown-item.wxml
+++ b/src/dropdown-menu/dropdown-item.wxml
@@ -19,6 +19,7 @@
     t-class-content="{{classPrefix}}__content {{prefix}}-class-content"
   >
     <view class="{{classPrefix}}__body">
+      <!-- 单选列表 -->
       <t-radio-group
         wx:if="{{!multiple}}"
         class="{{classPrefix}}__radio {{prefix}}-class-column"
@@ -26,19 +27,20 @@
         value="{{value}}"
         bind:change="handleRadioChange"
       >
-        <t-radio
-          wx:for="{{options}}"
-          wx:key="index"
-          class="{{classPrefix}}__radio-item {{prefix}}-class-column-item"
-          icon="line"
-          align="right"
-          t-class="radio"
-          t-class-label="{{prefix}}-class-column-item-label"
-          value="{{item[valueAlias]}}"
-          label="{{item[labelAlias]}}"
-          disabled="{{item.disabled}}"
-        ></t-radio>
+        <block wx:for="{{options}}" wx:key="index" tabindex="0">
+          <t-radio
+            class="{{classPrefix}}__radio-item {{prefix}}-class-column-item"
+            icon="line"
+            align="right"
+            t-class="radio"
+            t-class-label="{{prefix}}-class-column-item-label"
+            value="{{item[valueAlias]}}"
+            label="{{item[labelAlias]}}"
+            disabled="{{item.disabled}}"
+          ></t-radio>
+        </block>
       </t-radio-group>
+      <!-- 多选列表 -->
       <t-checkbox-group
         wx:else
         class="{{classPrefix}}__checkbox {{prefix}}-class-column"
@@ -47,7 +49,7 @@
         value="{{value}}"
         bind:change="handleRadioChange"
       >
-        <block wx:for="{{options}}" wx:key="index">
+        <block wx:for="{{options}}" wx:key="index" tabindex="0">
           <t-checkbox
             class="{{classPrefix}}__checkbox-item {{prefix}}-class-column-item"
             theme="tag"

--- a/src/dropdown-menu/dropdown-menu.ts
+++ b/src/dropdown-menu/dropdown-menu.ts
@@ -39,8 +39,8 @@ export default class DropdownMenu extends SuperComponent {
   methods = {
     toggle(index: number) {
       const { activeIdx, duration } = this.data;
-      const prevItem = this.nodes[activeIdx];
-      const currItem = this.nodes[index];
+      const prevItem = this.$children[activeIdx];
+      const currItem = this.$children[index];
 
       if (currItem?.data.disabled) return;
 
@@ -80,15 +80,8 @@ export default class DropdownMenu extends SuperComponent {
       }
     },
     getAllItems() {
-      const nodes = this.getRelationNodes('./dropdown-item');
-      const menus = nodes.map(({ data }) => ({
-        label: data.label,
-        disabled: data.disabled,
-        optionsColumns: data.optionsColumns,
-        multiple: data.multiple,
-      }));
+      const menus = this.$children.map(({ data }) => ({ label: data.label, disabled: data.disabled }));
 
-      this.nodes = nodes;
       this.setData({
         menus,
       });

--- a/src/dropdown-menu/dropdown-menu.ts
+++ b/src/dropdown-menu/dropdown-menu.ts
@@ -81,7 +81,12 @@ export default class DropdownMenu extends SuperComponent {
     },
     getAllItems() {
       const nodes = this.getRelationNodes('./dropdown-item');
-      const menus = nodes.map(({ data }) => ({ label: data.label, disabled: data.disabled }));
+      const menus = nodes.map(({ data }) => ({
+        label: data.label,
+        disabled: data.disabled,
+        optionsColumns: data.optionsColumns,
+        multiple: data.multiple,
+      }));
 
       this.nodes = nodes;
       this.setData({

--- a/src/dropdown-menu/dropdown-menu.ts
+++ b/src/dropdown-menu/dropdown-menu.ts
@@ -39,8 +39,8 @@ export default class DropdownMenu extends SuperComponent {
   methods = {
     toggle(index: number) {
       const { activeIdx, duration } = this.data;
-      const prevItem = this.$children[activeIdx];
-      const currItem = this.$children[index];
+      const prevItem = this.nodes[activeIdx];
+      const currItem = this.nodes[index];
 
       if (currItem?.data.disabled) return;
 
@@ -80,8 +80,10 @@ export default class DropdownMenu extends SuperComponent {
       }
     },
     getAllItems() {
-      const menus = this.$children.map(({ data }) => ({ label: data.label, disabled: data.disabled }));
+      const nodes = this.getRelationNodes('./dropdown-item');
+      const menus = nodes.map(({ data }) => ({ label: data.label, disabled: data.disabled }));
 
+      this.nodes = nodes;
       this.setData({
         menus,
       });

--- a/src/dropdown-menu/dropdown-menu.wxml
+++ b/src/dropdown-menu/dropdown-menu.wxml
@@ -7,7 +7,6 @@
     bindtap="handleToggle"
     data-index="{{index}}"
     class="{{_.cls(classPrefix + '__item', [['active', activeIdx == index], ['disabled', item.disabled]])}} {{prefix}}-class-item"
-    aria-hidden="{{activeIdx !== -1 && activeIdx !== index }}"
     aria-disabled="{{item.disabled}}"
     aria-role="button"
     aria-expanded="{{activeIdx === index}}"

--- a/src/dropdown-menu/dropdown-menu.wxml
+++ b/src/dropdown-menu/dropdown-menu.wxml
@@ -8,11 +8,12 @@
     data-index="{{index}}"
     class="{{_.cls(classPrefix + '__item', [['active', activeIdx == index], ['disabled', item.disabled]])}} {{prefix}}-class-item"
     aria-hidden="{{activeIdx !== -1 && activeIdx !== index }}"
-    aria-label="{{item.label}} 下拉{{item.multiple ? '多选' : '' }}{{item.optionsColumns > 1 ? item.optionsColumns+'列' : ''}}菜单 {{activeIdx === index ? '已展开' : '未展开'}}"
     aria-disabled="{{item.disabled}}"
     aria-role="button"
+    aria-expanded="{{activeIdx === index}}"
+    aria-haspopup="menu"
   >
-    <view class="{{classPrefix}}__title {{prefix}}-class-label" aria-hidden="{{true}}">{{item.label}}</view>
+    <view class="{{classPrefix}}__title {{prefix}}-class-label">{{item.label}}</view>
     <t-icon
       name="caret-down-small"
       t-class="{{prefix}}-class-icon"

--- a/src/dropdown-menu/dropdown-menu.wxml
+++ b/src/dropdown-menu/dropdown-menu.wxml
@@ -7,12 +7,17 @@
     bindtap="handleToggle"
     data-index="{{index}}"
     class="{{_.cls(classPrefix + '__item', [['active', activeIdx == index], ['disabled', item.disabled]])}} {{prefix}}-class-item"
+    aria-hidden="{{activeIdx !== -1 && activeIdx !== index }}"
+    aria-label="{{item.label}} 下拉{{item.multiple ? '多选' : '' }}{{item.optionsColumns > 1 ? item.optionsColumns+'列' : ''}}菜单 {{activeIdx === index ? '已展开' : '未展开'}}"
+    aria-disabled="{{item.disabled}}"
+    aria-role="button"
   >
-    <view class="{{classPrefix}}__title {{prefix}}-class-label">{{item.label}}</view>
+    <view class="{{classPrefix}}__title {{prefix}}-class-label" aria-hidden="{{true}}">{{item.label}}</view>
     <t-icon
       name="caret-down-small"
       t-class="{{prefix}}-class-icon"
       class="{{classPrefix}}__icon {{classPrefix}}__icon--{{activeIdx == index ? 'active' : ''}}"
+      aria-hidden="{{true}}"
     />
   </view>
   <slot />

--- a/src/radio/radio.less
+++ b/src/radio/radio.less
@@ -29,7 +29,9 @@
   font-size: @radio-font-size;
   background: @radio-bg-color;
   position: relative;
-
+  &:focus {
+    outline: 0;
+  }
   &--block {
     display: flex;
     padding: @radio-vertical-padding;

--- a/src/radio/radio.wxml
+++ b/src/radio/radio.wxml
@@ -8,6 +8,7 @@
   aria-checked="{{checked}}"
   aria-label="{{label + content}}"
   aria-disabled="{{disabled}}"
+  tabindex="{{tabindex}}"
 >
   <view
     class="{{_.cls(classPrefix + '__icon', [align, ['checked', checked], ['disabled', disabled]])}} {{prefix}}-class-icon"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1047

### 💡 需求背景和解决方案
给dropdown-menu增加了对应的label，将item的文字以及icon合并，一个item激活时，其他item暂时隐藏。
dropdown-item的选项增加tabindex以实现展开时快速聚焦。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(DropdownMenu): 支持无障碍访问

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 视频

https://user-images.githubusercontent.com/44339196/209605571-14508a81-b3b8-4a2d-9d49-d80ef7c8d4ce.mp4


https://user-images.githubusercontent.com/44339196/209605592-069fd362-64a5-4842-9f7f-4b289e8fa52a.mp4

