### PR TITLE
fix(Textarea): support adaptive parent container height

### DIFF
--- a/src/textarea/__test__/__snapshots__/demo.test.js.snap
+++ b/src/textarea/__test__/__snapshots__/demo.test.js.snap
@@ -16,6 +16,7 @@ exports[`Textarea Textarea base demo works fine 1`] = `
   <t-textarea
     disableDefaultPadding="{{true}}"
     placeholder="请输入文字"
+    tClass="external-class"
   />
 </base>
 `;
@@ -32,6 +33,7 @@ exports[`Textarea Textarea card demo works fine 1`] = `
       label="标签文字"
       maxlength="500"
       placeholder="请输入文字"
+      tClass="external-class"
     />
   </wx-view>
 </card>
@@ -49,10 +51,12 @@ exports[`Textarea Textarea custom demo works fine 1`] = `
     </wx-text>
     <t-textarea
       bordered="{{true}}"
+      customStyle="height: 248rpx"
       disableDefaultPadding="{{true}}"
       indicator="{{true}}"
       maxlength="100"
       placeholder="请输入文字"
+      tClass="external-class"
     />
   </wx-view>
 </custom>
@@ -65,6 +69,7 @@ exports[`Textarea Textarea disabled demo works fine 1`] = `
     disableDefaultPadding="{{true}}"
     label="标签文字"
     placeholder="请输入文字"
+    tClass="external-class"
     value="不可编辑文字"
   />
 </disabled>
@@ -76,6 +81,7 @@ exports[`Textarea Textarea label demo works fine 1`] = `
     disableDefaultPadding="{{true}}"
     label="标签文字"
     placeholder="请输入文字"
+    tClass="external-class"
   />
 </wx-label>
 `;
@@ -88,6 +94,7 @@ exports[`Textarea Textarea maxcharacter demo works fine 1`] = `
     label="标签文字"
     maxcharacter="200"
     placeholder="设置最大字符个数，一个汉字表示两个字符"
+    tClass="external-class"
   />
 </maxcharacter>
 `;
@@ -100,6 +107,7 @@ exports[`Textarea Textarea maxlength demo works fine 1`] = `
     label="标签文字"
     maxlength="200"
     placeholder="设置最大字符个数"
+    tClass="external-class"
   />
 </maxlength>
 `;

--- a/src/textarea/_example/base/index.wxml
+++ b/src/textarea/_example/base/index.wxml
@@ -1,1 +1,1 @@
-<t-textarea placeholder="请输入文字" disableDefaultPadding="{{true}}" />
+<t-textarea t-class="external-class" placeholder="请输入文字" disableDefaultPadding="{{true}}" />

--- a/src/textarea/_example/base/index.wxss
+++ b/src/textarea/_example/base/index.wxss
@@ -1,0 +1,3 @@
+.external-class {
+  height: 256rpx;
+}

--- a/src/textarea/_example/card/index.wxml
+++ b/src/textarea/_example/card/index.wxml
@@ -1,5 +1,6 @@
 <view class="textarea-example">
   <t-textarea
+    t-class="external-class"
     label="标签文字"
     placeholder="请输入文字"
     maxlength="500"

--- a/src/textarea/_example/card/index.wxss
+++ b/src/textarea/_example/card/index.wxss
@@ -5,5 +5,5 @@
 }
 
 .external-class {
-  height: 212rpx;
+  height: 312rpx;
 }

--- a/src/textarea/_example/card/index.wxss
+++ b/src/textarea/_example/card/index.wxss
@@ -3,3 +3,7 @@
   background-color: #fff;
   border-radius: 18rpx;
 }
+
+.external-class {
+  height: 212rpx;
+}

--- a/src/textarea/_example/custom/index.js
+++ b/src/textarea/_example/custom/index.js
@@ -1,1 +1,5 @@
-Component({});
+Component({
+  data: {
+    customStyle: 'height: 248rpx',
+  },
+});

--- a/src/textarea/_example/custom/index.wxml
+++ b/src/textarea/_example/custom/index.wxml
@@ -1,4 +1,12 @@
 <view class="textarea-example">
   <text class="textarea-example__label">标签文字</text>
-  <t-textarea placeholder="请输入文字" bordered maxlength="100" disableDefaultPadding="{{true}}" indicator />
+  <t-textarea
+    t-class="external-class"
+    placeholder="请输入文字"
+    bordered
+    maxlength="100"
+    disableDefaultPadding="{{true}}"
+    indicator
+    customStyle="{{customStyle}}"
+  />
 </view>

--- a/src/textarea/_example/custom/index.wxss
+++ b/src/textarea/_example/custom/index.wxss
@@ -1,6 +1,11 @@
 .textarea-example {
-  padding: 32rpx;
+  padding: 32rpx 32rpx 48rpx;
   background-color: #fff;
+}
+
+.external-class {
+  padding-top: 24rpx !important;
+  padding-bottom: 24rpx !important;
 }
 
 .textarea-example__label {

--- a/src/textarea/_example/disabled/index.wxml
+++ b/src/textarea/_example/disabled/index.wxml
@@ -1,1 +1,8 @@
-<t-textarea label="标签文字" placeholder="请输入文字" value="不可编辑文字" disableDefaultPadding="{{true}}" disabled />
+<t-textarea
+  t-class="external-class"
+  label="标签文字"
+  placeholder="请输入文字"
+  value="不可编辑文字"
+  disableDefaultPadding="{{true}}"
+  disabled
+/>

--- a/src/textarea/_example/disabled/index.wxss
+++ b/src/textarea/_example/disabled/index.wxss
@@ -1,0 +1,3 @@
+.external-class {
+  height: 256rpx;
+}

--- a/src/textarea/_example/label/index.wxml
+++ b/src/textarea/_example/label/index.wxml
@@ -1,1 +1,1 @@
-<t-textarea label="标签文字" placeholder="请输入文字" disableDefaultPadding="{{true}}" />
+<t-textarea t-class="external-class" label="标签文字" placeholder="请输入文字" disableDefaultPadding="{{true}}" />

--- a/src/textarea/_example/label/index.wxss
+++ b/src/textarea/_example/label/index.wxss
@@ -1,0 +1,3 @@
+.external-class {
+  height: 256rpx;
+}

--- a/src/textarea/_example/maxcharacter/index.wxml
+++ b/src/textarea/_example/maxcharacter/index.wxml
@@ -1,4 +1,5 @@
 <t-textarea
+  t-class="external-class"
   label="标签文字"
   placeholder="设置最大字符个数，一个汉字表示两个字符"
   maxcharacter="200"

--- a/src/textarea/_example/maxcharacter/index.wxss
+++ b/src/textarea/_example/maxcharacter/index.wxss
@@ -1,0 +1,3 @@
+.external-class {
+  height: 324rpx;
+}

--- a/src/textarea/_example/maxlength/index.wxml
+++ b/src/textarea/_example/maxlength/index.wxml
@@ -1,4 +1,5 @@
 <t-textarea
+  t-class="external-class"
   label="标签文字"
   placeholder="设置最大字符个数"
   maxlength="200"

--- a/src/textarea/_example/maxlength/index.wxss
+++ b/src/textarea/_example/maxlength/index.wxss
@@ -1,0 +1,3 @@
+.external-class {
+  height: 324rpx;
+}

--- a/src/textarea/_example/textarea.less
+++ b/src/textarea/_example/textarea.less
@@ -1,4 +1,0 @@
-.textarea-example {
-  padding-bottom: constant(safe-area-inset-bottom); /* 兼容 iOS < 11.2 */
-  padding-bottom: env(safe-area-inset-bottom); /* 兼容 iOS >= 11.2 */
-}

--- a/src/textarea/_example/textarea.wxml
+++ b/src/textarea/_example/textarea.wxml
@@ -1,4 +1,4 @@
-<view class="textarea-example">
+<view class="demo">
   <view class="demo-title">Textarea 多行文本框</view>
   <view class="demo-desc">用于多行文本信息输入。</view>
   <t-demo title="01 组件类型" desc="基础多行文本框">

--- a/src/textarea/textarea.less
+++ b/src/textarea/textarea.less
@@ -1,6 +1,5 @@
 @import '../common/style/index.less';
 
-@textarea-height: 144rpx; // 指定文本框高度
 @textarea-vertical-padding: 32rpx; // 文本框垂直方向间距
 @textarea-horizontal-padding: 32rpx; // 文本框水平方向间距
 @textarea-text-line-height: 48rpx; // 输入框文本行高
@@ -33,6 +32,9 @@
 @textarea-disabled-text-color: var(--td-textarea-disabled-text-color, @font-gray-4);
 
 .@{prefix}-textarea {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
   padding: @textarea-vertical-padding @textarea-horizontal-padding;
   background-color: @textarea-background-color;
 
@@ -47,13 +49,18 @@
   }
 
   &__wrapper {
+    display: flex;
+    flex-direction: column;
     width: 100%;
+    flex: 1 1 auto;
 
     &-inner {
+      flex: 1 1 auto;
       box-sizing: border-box;
       width: inherit;
-      height: @textarea-height;
       min-width: 0;
+      height: 100%;
+      min-height: 20px;
       margin: 0;
       padding: 0;
       text-align: left;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：通过 customStyle 修改父容器高度后，由于 textarea 高度固定不能自适应容器高度，导致指示器位置不正确
![wecom-temp-8667-165f3e0a90da962c358c8a82904c1e56](https://user-images.githubusercontent.com/51158141/211740603-ae7fa9fb-74e1-4258-b435-9aa836b36bd6.png)

方案： textarea 修改为自适应父容器高度，同时因为 autoSize 状态下文本框 style.height 为20px，这里为了保持与之一致，设置`min-height: 20px`

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): 支持自适应父容器高度

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
