### PR TITLE
fix(Button): fix style errors when using shape attribute

### DIFF
--- a/src/button/__test__/__snapshots__/demo.test.js.snap
+++ b/src/button/__test__/__snapshots__/demo.test.js.snap
@@ -225,7 +225,6 @@ exports[`Button Button shape demo works fine 1`] = `
   </wx-view>
   <t-button
     block="{{true}}"
-    shape="round"
     size="large"
     tClass="external-class"
     theme="primary"

--- a/src/button/_example/shape/index.wxml
+++ b/src/button/_example/shape/index.wxml
@@ -5,4 +5,4 @@
   <t-button theme="primary" size="large" icon="chevron-left" shape="circle" aria-label="返回"></t-button>
 </view>
 
-<t-button theme="primary" size="large" shape="round" block t-class="external-class">填充按钮</t-button>
+<t-button theme="primary" size="large" block t-class="external-class">填充按钮</t-button>

--- a/src/button/button.less
+++ b/src/button/button.less
@@ -389,21 +389,35 @@
 
   // 圆角长方形
   &--round {
-    &.@{button}--size {
-      &-large {
-        border-radius: calc(@button-large-height / 2);
-      }
+    &.@{button}--size-large {
+      border-radius: calc(@button-large-height / 2);
 
-      &-medium {
-        border-radius: calc(@button-medium-height / 2);
+      &::after {
+        border-radius: @button-large-height;
       }
+    }
 
-      &-small {
-        border-radius: calc(@button-small-height / 2);
+    &.@{button}--size-medium {
+      border-radius: calc(@button-medium-height / 2);
+
+      &::after {
+        border-radius: @button-medium-height;
       }
+    }
 
-      &-extra-small {
-        border-radius: calc(28px / 2);
+    &.@{button}--size-small {
+      border-radius: calc(@button-small-height / 2);
+
+      &::after {
+        border-radius: @button-small-height;
+      }
+    }
+
+    &.@{button}--size-extra-small {
+      border-radius: calc(@button-extra-small-height / 2);
+
+      &::after {
+        border-radius: @button-extra-small-height;
       }
     }
   }
@@ -412,48 +426,57 @@
   &--square {
     padding: 0;
 
-    &.@{button}--size {
-      &-large {
-        width: @button-large-height;
-      }
+    &.@{button}--size-large {
+      width: @button-large-height;
+    }
 
-      &-medium {
-        width: @button-medium-height;
-      }
+    &.@{button}--size-medium {
+      width: @button-medium-height;
+    }
 
-      &-small {
-        width: @button-small-height;
-      }
+    &.@{button}--size-small {
+      width: @button-small-height;
+    }
 
-      &-extra-small {
-        width: 28px;
-      }
+    &.@{button}--size-extra-small {
+      width: @button-extra-small-height;
     }
   }
 
   // 圆形
   &--circle {
     padding: 0;
+    border-radius: 50%;
 
-    &.@{button}--size {
-      &-large {
+    &.@{button}--size-large {
+      width: @button-large-height;
+
+      &::after {
         border-radius: 50%;
-        width: @button-large-height;
       }
+    }
 
-      &-medium {
+    &.@{button}--size-medium {
+      width: @button-medium-height;
+
+      &::after {
         border-radius: 50%;
-        width: @button-medium-height;
       }
+    }
 
-      &-small {
+    &.@{button}--size-small {
+      width: @button-small-height;
+
+      &::after {
         border-radius: 50%;
-        width: @button-small-height;
       }
+    }
 
-      &-extra-small {
+    &.@{button}--size-extra-small {
+      width: @button-extra-small-height;
+
+      &::after {
         border-radius: 50%;
-        width: 28px;
       }
     }
   }

--- a/src/button/button.ts
+++ b/src/button/button.ts
@@ -47,10 +47,10 @@ export default class Button extends SuperComponent {
       const classList = [
         name,
         `${prefix}-class`,
-        `${name}--${this.data.theme || 'default'}`,
-        `${name}--size-${this.data.size || 'medium'}`,
-        `${name}--${this.data.shape || 'rectangle'}`,
         `${name}--${this.data.variant || 'base'}`,
+        `${name}--${this.data.theme || 'default'}`,
+        `${name}--${this.data.shape || 'rectangle'}`,
+        `${name}--size-${this.data.size || 'medium'}`,
       ];
 
       if (this.data.block) {

--- a/src/calendar/__test__/__snapshots__/index.test.js.snap
+++ b/src/calendar/__test__/__snapshots__/index.test.js.snap
@@ -752,7 +752,7 @@ exports[`calendar :base 1`] = `
                 <wx-button
                   appParameter=""
                   ariaLabel=""
-                  class="t-button t-class t-button--primary t-button--size-medium t-button--rectangle t-button--base t-button--block"
+                  class="t-button t-class t-button--base t-button--primary t-button--rectangle t-button--size-medium t-button--block"
                   data-custom="{{null}}"
                   formType=""
                   hoverClass="t-button--hover"

--- a/src/sticky/__test__/__snapshots__/index.test.js.snap
+++ b/src/sticky/__test__/__snapshots__/index.test.js.snap
@@ -23,7 +23,7 @@ exports[`Sticky Props :base 1`] = `
             <wx-button
               appParameter=""
               ariaLabel=""
-              class="t-button t-class t-button--default t-button--size-medium t-button--rectangle t-button--base"
+              class="t-button t-class t-button--base t-button--default t-button--rectangle t-button--size-medium"
               data-custom="{{null}}"
               formType=""
               hoverClass="t-button--hover"
@@ -76,7 +76,7 @@ exports[`Sticky Props :base 1`] = `
             <wx-button
               appParameter=""
               ariaLabel=""
-              class="t-button t-class t-button--default t-button--size-medium t-button--rectangle t-button--base"
+              class="t-button t-class t-button--base t-button--default t-button--rectangle t-button--size-medium"
               data-custom="{{null}}"
               formType=""
               hoverClass="t-button--hover"
@@ -129,7 +129,7 @@ exports[`Sticky Props :base 1`] = `
             <wx-button
               appParameter=""
               ariaLabel=""
-              class="t-button t-class t-button--default t-button--size-medium t-button--rectangle t-button--base"
+              class="t-button t-class t-button--base t-button--default t-button--rectangle t-button--size-medium"
               data-custom="{{null}}"
               formType=""
               hoverClass="t-button--hover"
@@ -184,7 +184,7 @@ exports[`Sticky Props :base 1`] = `
               <wx-button
                 appParameter=""
                 ariaLabel=""
-                class="t-button t-class t-button--default t-button--size-medium t-button--rectangle t-button--base"
+                class="t-button t-class t-button--base t-button--default t-button--rectangle t-button--size-medium"
                 data-custom="{{null}}"
                 formType=""
                 hoverClass="t-button--hover"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景： 当使用 shape = ‘round'或‘circle’ 时，border样式不正确
截图：
![wecom-temp-2369-08983a29042bfaf3cfc42df1fdf23216](https://user-images.githubusercontent.com/51158141/211973358-f80abc13-4ab7-4ff3-bf82-3d7155842172.png)

最终效果：
<img width="370" alt="截屏2023-01-12 11 52 12" src="https://user-images.githubusercontent.com/51158141/211973571-7575219b-891c-49ef-9b36-f3f9bf5e96f8.png">

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- ffix(Button): 修复 `shape = 'round'` 或 `‘circle’` 时，`border`样式错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
