### PR TITLE
fix:修复下拉菜单遮罩层无法点击的问题

### DIFF
--- a/src/dropdown-item/dropdown-item.less
+++ b/src/dropdown-item/dropdown-item.less
@@ -31,7 +31,7 @@
     // 为了解决虚拟节点偶尔出现的问题
     display: block;
     width: 100%;
-    height: 100%;
+    height: max-content;
     overflow: hidden;
     position: absolute;
     left: 0;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #1613 

### 💡 需求背景和解决方案
### 📝 更新日志

- fix(DropdownMenu): 修复下拉菜单遮罩层无法点击

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
