### PR TITLE
fix: cls函数支持传入数值类型

### DIFF
--- a/src/col/col.wxml
+++ b/src/col/col.wxml
@@ -2,7 +2,7 @@
 <wxs src="./col.wxs" module="utils" />
 
 <view
-  class="class {{prefix}}-class {{ _.cls(classPrefix, [_.formatNumToString(span)]) }} {{ offset ? classPrefix + '--offset-' + offset : '' }}"
+  class="class {{prefix}}-class {{ _.cls(classPrefix, [span]) }} {{ offset ? classPrefix + '--offset-' + offset : '' }}"
   style="{{ utils.getColStyles({ gutter }) }}"
 >
   <slot />

--- a/src/common/utils.wxs
+++ b/src/common/utils.wxs
@@ -52,7 +52,7 @@ function cls(base, arr) {
       if (value) {
         res.push(base + '--' + key);
       }
-    } else if (typeof item === 'string') {
+    } else if (typeof item === 'string' || typeof item === 'number') {
       if (item) {
         res.push(base + '--' + item);
       }
@@ -124,14 +124,6 @@ function _style(styles) {
   return styles;
 }
 
-function formatNumToString(value) {
-  var res = '';
-  if (!isNaN(value) && typeof value === 'number') {
-    res = value.toString();
-  }
-  return res;
-}
-
 module.exports = {
   addUnit: addUnit,
   isString: isString,
@@ -142,5 +134,4 @@ module.exports = {
   cls: cls,
   getBadgeAriaLabel: getBadgeAriaLabel,
   _style: _style,
-  formatNumToString: formatNumToString,
 };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1701 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
row 组件和 col 组件的属性值要支持 string 类型

解决方案：修改 cls 方法，支持传入 number 类型
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Layout): row 组件和 col 组件的属性值支持 string 类型

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
