### PR TITLE
修复 button 组件 disableb 对控制 tap 无效问题

### DIFF
--- a/src/button/button.ts
+++ b/src/button/button.ts
@@ -92,7 +92,7 @@ export default class Button extends SuperComponent {
       this.triggerEvent('chooseavatar', e.detail);
     },
     handleTap(e) {
-      if (this.data.disabled) return;
+      if (this.data.disabled || this.data.loading) return;
 
       this.triggerEvent('tap', e);
     },

--- a/src/button/button.wxml
+++ b/src/button/button.wxml
@@ -18,7 +18,7 @@
   send-message-img="{{sendMessageImg}}"
   app-parameter="{{appParameter}}"
   show-message-card="{{showMessageCard}}"
-  catch:tap="{{ disabled || loading ? '' : 'handleTap'}}"
+  catch:tap="handleTap"
   bind:getuserinfo="getuserinfo"
   bind:contact="contact"
   bind:getphonenumber="getphonenumber"

--- a/src/button/button.wxml
+++ b/src/button/button.wxml
@@ -18,7 +18,7 @@
   send-message-img="{{sendMessageImg}}"
   app-parameter="{{appParameter}}"
   show-message-card="{{showMessageCard}}"
-  catch:tap="{{ disabled || loading ? '' : handleTap}}"
+  catch:tap="{{ disabled || loading ? '' : 'handleTap'}}"
   bind:getuserinfo="getuserinfo"
   bind:contact="contact"
   bind:getphonenumber="getphonenumber"

--- a/src/calendar/__test__/__snapshots__/index.test.js.snap
+++ b/src/calendar/__test__/__snapshots__/index.test.js.snap
@@ -771,7 +771,7 @@ exports[`calendar :base 1`] = `
                   bind:getuserinfo="getuserinfo"
                   bind:launchapp="launchapp"
                   bind:opensetting="opensetting"
-                  catch:tap=""
+                  catch:tap="handleTap"
                 >
                   <wx-view
                     class="t-button__content"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #1797 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
button 组件的 disableb 属性对控制 tap 无效问题
<img width="846" alt="image" src="https://user-images.githubusercontent.com/58472278/227201431-0a351f1d-6d8b-4c32-be7d-837cbf6bea07.png">

解决方案：catchtap 事件要触发，才能阻止事件冒泡
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Button): 修复 disabled = true 仍触发 tap 事件的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
