### PR TITLE
fix(image-viewer): add using-custom-navation property

### DIFF
--- a/src/common/style/_variables.less
+++ b/src/common/style/_variables.less
@@ -183,3 +183,6 @@
 @text-color-anti: var(--td-text-color-anti, @font-white-1);
 @text-color-brand: var(--td-text-color-brand, @brand-color);
 @text-color-link: var(--td-text-color-link, @brand-color);
+
+// 定位
+@position-fixed-top: var(--td-position-fixed-top, 0);

--- a/src/image-viewer/README.en-US.md
+++ b/src/image-viewer/README.en-US.md
@@ -1,0 +1,24 @@
+:: BASE_DOC ::
+
+## API
+### ImageViewer Props
+
+name | type | default | description | required
+-- | -- | -- | -- | --
+background-color | String | 'rgba(0, 0, 0, 1)' | \- | N
+close-btn | String / Boolean / Object / Slot | false | \- | N
+delete-btn | String / Boolean / Object / Slot | false | \- | N
+images | Array | [] | Typescript：`Array<string>` | N
+initial-index | Number | 0 | Typescript：`Number` | N
+show-index | Boolean | false | \- | N
+using-custom-navbar | Boolean | false | \- | N
+visible | Boolean | false | \- | N
+default-visible | Boolean | undefined | uncontrolled property | N
+
+### ImageViewer Events
+
+name | params | description
+-- | -- | --
+change | `(index: Number)` | \-
+close | `(trigger: 'overlay' \| 'button', visible: Boolean, index: Number)` | \-
+delete | `(index: Number)` | \-

--- a/src/image-viewer/README.md
+++ b/src/image-viewer/README.md
@@ -28,36 +28,37 @@ isComponent: true
 
 ### 类型
 
-基础图片预览
+#### 基础图片预览
 
 {{ base }}
 
-带操作图片预览
+#### 带操作图片预览
+
+顶部区域可以配置关闭按钮、页码信息、删除按钮。
 
 {{ delete }}
 
+> 当使用自定义导航栏的时候，顶部的操作按钮会被遮挡，此时需要开启 `using-custom-navbar` 来解决
 
 ## API
-
 ### ImageViewer Props
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-background-color | String / Number | rgba(0, 0, 0, 1) | 遮罩的背景颜色 | N
+background-color | String | 'rgba(0, 0, 0, 1)' | 遮罩的背景颜色 | N
+close-btn | String / Boolean / Object / Slot | false | 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标 | N
+delete-btn | String / Boolean / Object / Slot | false | 是否显示删除操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `delete`，值为 `Object` 类型，表示透传至 `icon`，不传表示不显示图标 | N
 images | Array | [] | 图片数组。TS 类型：`Array<string>` | N
-initial-index | Number | 0 | 默认展示第几项 | N
+initial-index | Number | 0 | 初始化页码。TS 类型：`Number` | N
 show-index | Boolean | false | 是否显示页码 | N
-delete-btn | Boolean / String / Object / Slot | false | 是否显示删除操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `delete`，值为 `Object` 类型，表示透传至 `icon`，不传表示不显示图标。 | N
-close-btn | Boolean / String / Object / Slot | false | 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标。 | N
+using-custom-navbar | Boolean | false | `v1.1.4` 是否使用了自定义导航栏 | N
 visible | Boolean | false | 隐藏/显示预览 | N
 default-visible | Boolean | undefined | 隐藏/显示预览。非受控属性 | N
-
 
 ### ImageViewer Events
 
 名称 | 参数 | 描述
 -- | -- | --
 change | `(index: Number)` | 翻页时回调
-close | `(trigger: 'overlay' \| 'button' , visible: Boolean, index: Number)` | 点击操作按钮button或者overlay时触发
+close | `(trigger: 'overlay' \| 'button', visible: Boolean, index: Number)` | 点击操作按钮button或者overlay时触发
 delete | `(index: Number)` | 点击删除操作按钮时触发
-

--- a/src/image-viewer/image-viewer.less
+++ b/src/image-viewer/image-viewer.less
@@ -10,10 +10,11 @@
 @image-viewer-nav-index-font-size: var(--td-image-viewer-nav-index-font-size, @font-size-base);
 @image-viewer-close-margin-left: var(--td-image-viewer-close-margin-left, @spacer-1);
 @image-viewer-delete-margin-right: var(--td-image-viewer-delete-margin-right, @spacer-1);
+@image-viewer-top: var(--td-image-viewer-top, @position-fixed-top);
 
 .@{image-viewer} {
   position: fixed;
-  top: 0;
+  top: @image-viewer-top;
   left: 0;
   bottom: 0;
   right: 0;
@@ -23,7 +24,7 @@
   overflow: hidden;
 
   &__mask {
-    position: fixed;
+    position: absolute;
     z-index: 1000;
     left: 0;
     top: 0;
@@ -56,7 +57,7 @@
 
   &__nav {
     width: 100%;
-    position: fixed;
+    position: absolute;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/image-viewer/image-viewer.ts
+++ b/src/image-viewer/image-viewer.ts
@@ -22,6 +22,7 @@ export default class ImageViewer extends SuperComponent {
     windowWidth: 0,
     swiperStyle: {},
     imagesStyle: {},
+    maskTop: 0,
   };
 
   options = {
@@ -37,6 +38,7 @@ export default class ImageViewer extends SuperComponent {
 
   ready() {
     this.saveScreenSize();
+    this.calcMaskTop();
   }
 
   observers = {
@@ -60,6 +62,18 @@ export default class ImageViewer extends SuperComponent {
   };
 
   methods = {
+    calcMaskTop() {
+      if (this.data.usingCustomNavbar) {
+        const rect = wx?.getMenuButtonBoundingClientRect() || null;
+        const { statusBarHeight } = wx.getSystemInfoSync();
+
+        if (rect && statusBarHeight) {
+          this.setData({
+            maskTop: rect.top - statusBarHeight + rect.bottom,
+          });
+        }
+      }
+    },
     saveScreenSize() {
       const { windowHeight, windowWidth } = wx.getSystemInfoSync();
       this.setData({

--- a/src/image-viewer/image-viewer.wxml
+++ b/src/image-viewer/image-viewer.wxml
@@ -5,7 +5,7 @@
   wx:if="{{visible}}"
   id="{{classPrefix}}"
   class="{{classPrefix}} class {{prefix}}-class"
-  style="{{_._style([style, customStyle])}}"
+  style="{{_._style([style, customStyle, '--td-image-viewer-top: ' + maskTop + 'px'])}}"
 >
   <view
     class="{{classPrefix}}__mask"

--- a/src/image-viewer/props.ts
+++ b/src/image-viewer/props.ts
@@ -9,15 +9,24 @@ const props: TdImageViewerProps = {
   /** 遮罩的背景颜色 */
   backgroundColor: {
     type: String,
-    optionalTypes: [Number],
     value: 'rgba(0, 0, 0, 1)',
+  },
+  /** 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标 */
+  closeBtn: {
+    type: null,
+    value: false,
+  },
+  /** 是否显示删除操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `delete`，值为 `Object` 类型，表示透传至 `icon`，不传表示不显示图标 */
+  deleteBtn: {
+    type: null,
+    value: false,
   },
   /** 图片数组 */
   images: {
     type: Array,
     value: [],
   },
-  /** 默认展示第几项 */
+  /** 初始化页码 */
   initialIndex: {
     type: Number,
     value: 0,
@@ -27,14 +36,9 @@ const props: TdImageViewerProps = {
     type: Boolean,
     value: false,
   },
-  /** 是否显示删除操作 */
-  deleteBtn: {
-    type: null,
-    value: false,
-  },
-  /** 是否显示关闭操作 */
-  closeBtn: {
-    type: null,
+  /** 是否使用了自定义导航栏 */
+  usingCustomNavbar: {
+    type: Boolean,
     value: false,
   },
   /** 隐藏/显示预览 */

--- a/src/image-viewer/type.ts
+++ b/src/image-viewer/type.ts
@@ -6,21 +6,28 @@
 
 export interface TdImageViewerProps {
   /**
-   * 自定义组件样式
-   * @default ''
+   * 遮罩的背景颜色
+   * @default 'rgba(0, 0, 0, 1)'
    */
-  style?: {
+  backgroundColor?: {
     type: StringConstructor;
     value?: string;
   };
   /**
-   * 遮罩的背景颜色
-   * @default rgba(0, 0, 0, .6)
+   * 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标
+   * @default false
    */
-  backgroundColor?: {
-    type: StringConstructor;
-    optionalTypes: Array<NumberConstructor>;
-    value?: string | number;
+  closeBtn?: {
+    type: null;
+    value?: string | boolean | object;
+  };
+  /**
+   * 是否显示删除操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `delete`，值为 `Object` 类型，表示透传至 `icon`，不传表示不显示图标
+   * @default false
+   */
+  deleteBtn?: {
+    type: null;
+    value?: string | boolean | object;
   };
   /**
    * 图片数组
@@ -31,12 +38,12 @@ export interface TdImageViewerProps {
     value?: Array<string>;
   };
   /**
-   * 默认展示第几项
+   * 初始化页码
    * @default 0
    */
   initialIndex?: {
     type: NumberConstructor;
-    value?: number;
+    value?: Number;
   };
   /**
    * 是否显示页码
@@ -46,15 +53,13 @@ export interface TdImageViewerProps {
     type: BooleanConstructor;
     value?: boolean;
   };
-  /** 是否显示删除操作 */
-  deleteBtn?: {
-    type: null;
-    value?: boolean | string | object;
-  };
-  /** 是否显示关闭操作 */
-  closeBtn?: {
-    type: null;
-    value?: boolean | string | object;
+  /**
+   * 是否使用了自定义导航栏
+   * @default false
+   */
+  usingCustomNavbar?: {
+    type: BooleanConstructor;
+    value?: boolean;
   };
   /**
    * 隐藏/显示预览


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #1904 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
开启自定义导航栏的时候，imageviewer 的顶部按钮会被遮挡，因此新增属性 usingCustomNavigation 用于调整 imageViewer 的顶部位置。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ImageViewer): 新增 usingCustomNavigation 属性，处理使用自定义导航栏时被遮挡的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
