### PR TITLE
fix: 修复多余 row 的样式导致 col 不换行问题

### DIFF
--- a/src/row/row.less
+++ b/src/row/row.less
@@ -1,8 +1,3 @@
-.t-row {
-  display: flex;
-  align-items: center;
-}
-
 .t-row:after {
   clear: both;
   content: '';


### PR DESCRIPTION
fix #1964, fix #1851

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#1964, #1851
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
因为#1851问题修改了 row 组件子节点的默认样式为垂直居中，但是layout组件应该是作为一个外框，里面内容的排列布局不应该和它相关，如果需要 col 组件中的内容垂直居中，应该自行添加样式处理 col 的内容，而且默认 row 组件子节点的样式为垂直居中也不适合于子节点为多行的情况，所以这里把这块样式删除，删除之后#1964的问题得到解决 。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(row): 删除对 row 组件的多余样式，修复 col 组件不换行问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
