### PR TITLE
feat(Textarea): support max/min height

### DIFF
--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -63,7 +63,7 @@ isComponent: true
 -- | -- | -- | -- | --
 adjust-position | Boolean | true | 键盘弹起时，是否自动上推页面 | N
 autofocus | Boolean | false | 自动聚焦，拉起键盘 | N
-autosize | Boolean | false | 是否自动增高，值为 autosize 时，style.height 不生效 | N
+autosize | Boolean / Object | false | 是否自动增高，值为 true 时，style.height 不生效。支持传入对象，如 { maxHeight: 120, minHeight: 20 } | N
 confirm-hold | Boolean | false | 点击键盘右下角按钮时是否保持键盘不收起点 | N
 confirm-type | String | done | 设置键盘右下角按钮的文字，仅在 type='text'时生效。可选项：send/search/next/go/done。TS 类型：`'return' \| 'send' \| 'search' \| 'next' \| 'go' \| 'done'` | N
 cursor-spacing | Number | 0 | 指定光标与键盘的距离。取textarea距离底部的距离和cursor-spacing指定的距离的最小值作为光标与键盘的距离 | N

--- a/src/textarea/__test__/__snapshots__/demo.test.js.snap
+++ b/src/textarea/__test__/__snapshots__/demo.test.js.snap
@@ -3,10 +3,16 @@
 exports[`Textarea Textarea autosize demo works fine 1`] = `
 <autosize>
   <t-textarea
-    autosize="{{true}}"
+    autosize="{{
+      Object {
+        "maxHeight": 120,
+        "minHeight": 20,
+      }
+    }}"
     disableDefaultPadding="{{true}}"
     label="标签文字"
     placeholder="请输入文字"
+    bind:line-change="onLineChange"
   />
 </autosize>
 `;

--- a/src/textarea/__test__/__snapshots__/index.test.js.snap
+++ b/src/textarea/__test__/__snapshots__/index.test.js.snap
@@ -41,6 +41,7 @@ exports[`textarea slots : label 1`] = `
         selectionEnd="{{-1}}"
         selectionStart="{{-1}}"
         showConfirmBar="{{true}}"
+        style=""
         value=""
         bind:blur="onBlur"
         bind:confirm="onConfirm"

--- a/src/textarea/__test__/__virtualHostSnapshot__/demo.test.js.snap
+++ b/src/textarea/__test__/__virtualHostSnapshot__/demo.test.js.snap
@@ -3,10 +3,16 @@
 exports[`Textarea Textarea autosize demo works fine 1`] = `
 <autosize>
   <t-textarea
-    autosize="{{true}}"
+    autosize="{{
+      Object {
+        "maxHeight": 120,
+        "minHeight": 20,
+      }
+    }}"
     disableDefaultPadding="{{true}}"
     label="标签文字"
     placeholder="请输入文字"
+    bind:line-change="onLineChange"
   />
 </autosize>
 `;

--- a/src/textarea/__test__/__virtualHostSnapshot__/index.test.js.snap
+++ b/src/textarea/__test__/__virtualHostSnapshot__/index.test.js.snap
@@ -41,6 +41,7 @@ exports[`textarea slots : label 1`] = `
         selectionEnd="{{-1}}"
         selectionStart="{{-1}}"
         showConfirmBar="{{true}}"
+        style=""
         value=""
         bind:blur="onBlur"
         bind:confirm="onConfirm"

--- a/src/textarea/_example/autosize/index.js
+++ b/src/textarea/_example/autosize/index.js
@@ -1,1 +1,13 @@
-Component({});
+Component({
+  data: {
+    autosize: {
+      maxHeight: 120,
+      minHeight: 20,
+    },
+  },
+  methods: {
+    onLineChange(e) {
+      console.log('lineCount: ', e.detail);
+    },
+  },
+});

--- a/src/textarea/_example/autosize/index.wxml
+++ b/src/textarea/_example/autosize/index.wxml
@@ -1,1 +1,7 @@
-<t-textarea label="标签文字" placeholder="请输入文字" disableDefaultPadding="{{true}}" autosize />
+<t-textarea
+  label="标签文字"
+  placeholder="请输入文字"
+  disableDefaultPadding="{{true}}"
+  autosize="{{autosize}}"
+  bind:line-change="onLineChange"
+/>

--- a/src/textarea/props.ts
+++ b/src/textarea/props.ts
@@ -18,7 +18,7 @@ const props: TdTextareaProps = {
   },
   /** 是否自动增高，值为 autosize 时，style.height 不生效 */
   autosize: {
-    type: Boolean,
+    type: null,
     value: false,
   },
   /** 点击键盘右下角按钮时是否保持键盘不收起点 */

--- a/src/textarea/textarea.wxml
+++ b/src/textarea/textarea.wxml
@@ -1,4 +1,5 @@
 <wxs src="../common/utils.wxs" module="_" />
+<wxs src="./textarea.wxs" module="this" />
 
 <view
   style="{{_._style([style, customStyle])}}"
@@ -11,18 +12,19 @@
   <view class="{{classPrefix}}__wrapper">
     <textarea
       class="{{classPrefix}}__wrapper-inner {{disabled? prefix +  '-is-disabled' : ''}} {{prefix}}-class-textarea"
+      style="{{this.textareaStyle(autosize)}}"
       maxlength="{{maxlength}}"
       disabled="{{disabled}}"
       placeholder="{{placeholder}}"
       placeholder-class="{{classPrefix}}__placeholder"
       placeholder-style="{{placeholderStyle}}"
       value="{{value}}"
+      auto-height="{{!!autosize}}"
       auto-focus="{{autofocus}}"
       fixed="{{fixed}}"
       focus="{{focus}}"
       cursor="{{cursor}}"
       cursor-spacing="{{cursorSpacing}}"
-      auto-height="{{autosize}}"
       adjust-position="{{adjustPosition}}"
       confirm-type="{{confirmType}}"
       confirm-hold="{{confirmHold}}"

--- a/src/textarea/textarea.wxs
+++ b/src/textarea/textarea.wxs
@@ -1,0 +1,16 @@
+/* eslint-disable */
+var utils = require('../common/utils.wxs');
+
+function textareaStyle(autosize) {
+  if (autosize && autosize.constructor === 'Object') {
+    return utils._style({
+      'min-height': utils.addUnit(autosize.minHeight),
+      'max-height': utils.addUnit(autosize.maxHeight),
+    });
+  }
+  return '';
+}
+
+module.exports = {
+  textareaStyle: textareaStyle,
+};

--- a/src/textarea/type.ts
+++ b/src/textarea/type.ts
@@ -26,8 +26,8 @@ export interface TdTextareaProps {
    * @default false
    */
   autosize?: {
-    type: BooleanConstructor;
-    value?: boolean;
+    type: null;
+    value?: boolean | object;
   };
   /**
    * 点击键盘右下角按钮时是否保持键盘不收起点


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：autosize 控制最大最小行数
方案：autosize 支持传入对象，如 { maxHeight: 120, minHeight: 20 }，以此控制最大最小行数

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Textarea):  属性 autoSize 支持控制最大最小高度

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
