### PR TITLE
fix(Sticky): resolved width problem

### DIFF
--- a/src/sticky/README.md
+++ b/src/sticky/README.md
@@ -44,7 +44,7 @@ isComponent: true
 -- | -- | -- | -- | --
 container | Function | - | 函数返回容器对应的 NodesRef 节点，将对应节点指定为组件的外部容器，滚动时组件会始终保持在容器范围内，当组件即将超出容器底部时，会返回原位置。 | N
 disabled | Boolean | false | 是否禁用组件 | N
-external-classes | Array | - | 根结点外部样式。`['t-class']` | N
+external-classes | Array | - | 根结点外部样式。`['t-class', 't-class-content']` | N
 offset-top | String / Number | 0 | 吸顶时与顶部的距离，单位`px` | N
 z-index | Number | 99 | 吸顶时的 z-index | N
 

--- a/src/sticky/__test__/index.test.js
+++ b/src/sticky/__test__/index.test.js
@@ -35,7 +35,7 @@ describe('Sticky Props', () => {
 
     simulate.scroll($demo, 500, 4);
     await simulate.sleep(20);
-    expect($sticky.instance.data.contentStyle).toBe('position:fixed;top:0px;');
+    expect($sticky.instance.data.contentStyle).toBe('position:fixed;top:0px;left:0;right:0;');
   });
 
   it(':offset-top', async () => {
@@ -46,7 +46,7 @@ describe('Sticky Props', () => {
 
     simulate.scroll($demo, 500, 4);
     await simulate.sleep(20);
-    expect($sticky.instance.data.contentStyle).toBe('position:fixed;top:100px;');
+    expect($sticky.instance.data.contentStyle).toBe('position:fixed;top:100px;left:0;right:0;');
   });
 
   it(':disabled', async () => {

--- a/src/sticky/sticky.less
+++ b/src/sticky/sticky.less
@@ -2,8 +2,4 @@
 
 .@{prefix}-sticky {
   position: relative;
-
-  &__content {
-    width: fit-content;
-  }
 }

--- a/src/sticky/sticky.ts
+++ b/src/sticky/sticky.ts
@@ -14,7 +14,7 @@ export interface StickyProps extends TdStickyProps {}
 
 @wxComponent()
 export default class Sticky extends SuperComponent {
-  externalClasses = [`${prefix}-class`];
+  externalClasses = [`${prefix}-class`, `${prefix}-class-content`];
 
   properties = props;
 
@@ -99,7 +99,7 @@ export default class Sticky extends SuperComponent {
 
         if (isFixed) {
           containerStyle += `height:${height}px;`;
-          contentStyle += `position:fixed;top:${offsetTop}px;`;
+          contentStyle += `position:fixed;top:${offsetTop}px;left:0;right:0;`;
         }
         if (transform) {
           const translate = `translate3d(0, ${transform}px, 0)`;

--- a/src/sticky/sticky.wxml
+++ b/src/sticky/sticky.wxml
@@ -4,7 +4,7 @@
   class="{{classPrefix}} class {{prefix}}-class"
   style="{{_._style(['z-index:' + zIndex, containerStyle, style, customStyle])}};"
 >
-  <view class="{{prefix}}-class-content" style="z-index:{{ zIndex }};{{ contentStyle }};">
+  <view class="{{classPrefix}}__content {{prefix}}-class-content" style="z-index:{{ zIndex }};{{ contentStyle }};">
     <slot />
   </view>
 </view>

--- a/src/sticky/sticky.wxml
+++ b/src/sticky/sticky.wxml
@@ -2,9 +2,9 @@
 
 <view
   class="{{classPrefix}} class {{prefix}}-class"
-  style="{{_._style(['z-index:' + zIndex, containerStyle, style, customStyle])}}"
+  style="{{_._style(['z-index:' + zIndex, containerStyle, style, customStyle])}};"
 >
-  <view class="{{classPrefix}}__content" style="z-index:{{ zIndex }};{{ contentStyle }}">
+  <view class="{{prefix}}-class-content" style="z-index:{{ zIndex }};{{ contentStyle }};">
     <slot />
   </view>
 </view>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2006
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
其他说明：sticky 组件外层的 margin 和 padding在锁定状态下会出现内容溢出问题，视图是从上到下、从左到右渲染，所以看上去右边距消失了。 这里，我们新提供了一个外部样式类 `t-class-content`，可以通过这个类直接给sticky组件的content内容边距。
```html
<t-sticky t-class-content="class-content">
  <t-button size="large" theme="primary" t-class="external-class">基础吸顶</t-button>
</t-sticky>
```
```css
.class-content {
  margin: 0 30rpx;
}
```
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Sticky): 解决 fixed 定位时宽度错误
- feat(Sticky): 补充外部样式类`t-class-content`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
