### PR TITLE
Fix/20230715 wrong label

### DIFF
--- a/src/message/message.wxml
+++ b/src/message/message.wxml
@@ -1,8 +1,6 @@
 <wxs src="./message.wxs" module="this"></wxs>
 <wxs src="../common/utils.wxs" module="_" />
-
 <import src="../common/template/icon.wxml" />
-
 <block wx:if="{{visible}}">
   <view
     class="{{classPrefix}} class {{prefix}}-class {{classPrefix}}--{{theme}}"
@@ -15,9 +13,8 @@
       <slot name="icon" />
       <template wx:if="{{_icon}}" is="icon" data="{{tClass: prefix + '-class-icon', ariaHidden: true, ..._icon }}" />
     </view>
-
     <view
-      class="{{classPrefix}}__text-wrap {{marquee ? '{{classPrefix}}__text-nowrap' : ''}}"
+      class="{{classPrefix}}__text-wrap {{true ? classPrefix + '__text-nowrap' : ''}}"
       style="text-align: {{align}}"
       id="{{classPrefix}}__text-wrap"
     >
@@ -43,7 +40,6 @@
       bind:complete="handleLinkClick"
     />
     <slot name="link" />
-
     <view class="{{classPrefix}}__icon--right" bind:tap="handleClose">
       <slot name="close-btn" />
       <template

--- a/src/message/message.wxml
+++ b/src/message/message.wxml
@@ -14,7 +14,7 @@
       <template wx:if="{{_icon}}" is="icon" data="{{tClass: prefix + '-class-icon', ariaHidden: true, ..._icon }}" />
     </view>
     <view
-      class="{{classPrefix}}__text-wrap {{true ? classPrefix + '__text-nowrap' : ''}}"
+      class="{{classPrefix}}__text-wrap {{marquee ? {{classPrefix}} + '__text-nowrap' : ''}}"
       style="text-align: {{align}}"
       id="{{classPrefix}}__text-wrap"
     >

--- a/src/message/message.wxml
+++ b/src/message/message.wxml
@@ -14,7 +14,7 @@
       <template wx:if="{{_icon}}" is="icon" data="{{tClass: prefix + '-class-icon', ariaHidden: true, ..._icon }}" />
     </view>
     <view
-      class="{{classPrefix}}__text-wrap {{marquee ? {{classPrefix}} + '__text-nowrap' : ''}}"
+      class="{{classPrefix}}__text-wrap {{marquee ? classPrefix + '__text-nowrap' : ''}}"
       style="text-align: {{align}}"
       id="{{classPrefix}}__text-wrap"
     >

--- a/src/slider/slider.wxml
+++ b/src/slider/slider.wxml
@@ -22,7 +22,7 @@
           style="left:{{item.left}}px; transform: translateX(-50%);"
           aria-hidden="{{true}}"
         >
-          <view wx:if="{{scaleTextArray.length}}" class="{{_.cls(classPrefix + '__scale-desc', [theme])}}}}">
+          <view wx:if="{{scaleTextArray.length}}" class="{{_.cls(classPrefix + '__scale-desc', [theme])}}">
             {{scaleTextArray[index]}}
           </view>
         </view>


### PR DESCRIPTION
message nowrap 属性中的 classPrefix 被当做字符串处理，导致无法正常使用。slider 组件中多出来了一对闭合大括号，导致无法正常匹配

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
暂无
### 💡 需求背景和解决方案

1. message 原有的实现为 `{{marquee ? '{{classPrefix}}__text-nowrap' : ''}}` 这会导致无法正常应用 classPrefix。
2. 原来 slider 组件中有一处大括号无法正常匹配，导致配合其他跨端框架使用时直接报错。

### 📝 更新日志

- fix(Message): 修复 `__text-nowrap` 类名前缀错误的问题
- fix(Slider): 移除错误的 wxml。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
