### PR TITLE
fix(popup): resolve auto focus

### DIFF
--- a/src/calendar/__test__/__snapshots__/index.test.js.snap
+++ b/src/calendar/__test__/__snapshots__/index.test.js.snap
@@ -8,8 +8,6 @@ exports[`calendar :base 1`] = `
       bind:visible-change="onVisibleChange"
     >
       <wx-view
-        ariaModal="{{true}}"
-        ariaRole="dialog"
         class="t-popup t-popup--bottom t-fade-enter t-fade-enter-active class t-class"
         style="z-index:11500;"
         bind:transitionend="onTransitionEnd"

--- a/src/date-time-picker/__test__/__snapshots__/index.test.js.snap
+++ b/src/date-time-picker/__test__/__snapshots__/index.test.js.snap
@@ -16,8 +16,6 @@ exports[`date-time-picker :base 1`] = `
         bind:visible-change="onPopupChange"
       >
         <wx-view
-          ariaModal="{{true}}"
-          ariaRole="dialog"
           class="t-popup t-popup--bottom t-fade-enter t-fade-enter-active class t-class"
           style="z-index:11500;"
           bind:transitionend="onTransitionEnd"

--- a/src/dialog/__test__/__snapshots__/index.test.js.snap
+++ b/src/dialog/__test__/__snapshots__/index.test.js.snap
@@ -11,8 +11,6 @@ exports[`dialog :base 1`] = `
       bind:visible-change="overlayClick"
     >
       <wx-view
-        ariaModal="{{true}}"
-        ariaRole="dialog"
         class="t-popup t-popup--center t-dialog-enter t-dialog-enter-active class t-class"
         style="z-index:11500;"
         bind:transitionend="onTransitionEnd"

--- a/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
+++ b/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
@@ -87,8 +87,6 @@ exports[`dropdown-menu :base 1`] = `
             bind:visible-change="handleMaskClick"
           >
             <wx-view
-              ariaModal="{{true}}"
-              ariaRole="dialog"
               class="t-popup t-popup--top t-fade-enter-active t-fade-enter-to class t-class"
               style="z-index:11601; position: absolute;"
               bind:transitionend="onTransitionEnd"

--- a/src/picker/__test__/__snapshots__/index.test.js.snap
+++ b/src/picker/__test__/__snapshots__/index.test.js.snap
@@ -13,8 +13,6 @@ exports[`picker :base 1`] = `
     bind:visible-change="onPopupChange"
   >
     <wx-view
-      ariaModal="{{true}}"
-      ariaRole="dialog"
       class="t-popup t-popup--bottom t-fade-enter t-fade-enter-active class t-class"
       style="z-index:11500;"
       bind:transitionend="onTransitionEnd"

--- a/src/popup/popup.wxml
+++ b/src/popup/popup.wxml
@@ -6,9 +6,8 @@
   style="{{_._style([utils.getPopupStyles(zIndex), style, customStyle])}}"
   class="{{_.cls(classPrefix, [placement])}} {{transitionClass}} class {{prefix}}-class"
   bind:transitionend="onTransitionEnd"
-  aria-role="dialog"
-  aria-modal="{{ true }}"
 >
+  <!-- 暂时移除：aria-role="dialog" aria-modal="{{ true }}"，关联：https://github.com/Tencent/tdesign-miniprogram/issues/2142 -->
   <view class="{{classPrefix}}__content {{prefix}}-class-content">
     <slot name="content" />
     <slot />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #2142
fix #2083 
fix #2026

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
因为增加 a11y 的属性，导致在 Android 的机器上，打开 Popup 会自动聚焦到第一个可聚焦的元素上。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popup): 解决自动聚焦的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
