### PR TITLE
docs(tabs): correct tabs example have same value

### DIFF
--- a/src/tabs/__test__/__snapshots__/demo.test.js.snap
+++ b/src/tabs/__test__/__snapshots__/demo.test.js.snap
@@ -56,7 +56,7 @@ exports[`Tabs Tabs base demo works fine 1`] = `
     />
     <t-tab-panel
       label="上限四字"
-      value="2"
+      value="3"
     />
   </t-tabs>
   <t-tabs

--- a/src/tabs/__test__/__virtualHostSnapshot__/demo.test.js.snap
+++ b/src/tabs/__test__/__virtualHostSnapshot__/demo.test.js.snap
@@ -56,7 +56,7 @@ exports[`Tabs Tabs base demo works fine 1`] = `
     />
     <t-tab-panel
       label="上限四字"
-      value="2"
+      value="3"
     />
   </t-tabs>
   <t-tabs

--- a/src/tabs/_example/base/index.wxml
+++ b/src/tabs/_example/base/index.wxml
@@ -13,7 +13,7 @@
   <t-tab-panel label="选项" value="0" />
   <t-tab-panel label="选项" value="1" />
   <t-tab-panel label="选项" value="2" />
-  <t-tab-panel label="上限四字" value="2" />
+  <t-tab-panel label="上限四字" value="3" />
 </t-tabs>
 
 <t-tabs


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


### 💡 需求背景和解决方案

现在[tabs文档](https://tdesign.tencent.com/miniprogram/components/tabs)里【基础选项卡】的第3个示例代码存在相同的value。这会导致：
1. 右侧的预览中，无法点击第3行第4个“上限四字”tab；
2. 有人(比如我...)把这段代码复制到本地后，会发现点击不了tab；

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
