### PR TITLE
fix(side-bar-item): 修复激活项的兄弟项点击热区部分丢失的问题

### DIFF
--- a/src/side-bar-item/side-bar-item.less
+++ b/src/side-bar-item/side-bar-item.less
@@ -43,6 +43,7 @@
     width: 100%;
     height: calc(@side-bar-border-radius * 2);
     background: #fff;
+    pointer-events: none;
 
     &::after {
       content: '';


### PR DESCRIPTION
fix #2430

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2430

### 💡 需求背景和解决方案

激活项的prefix与suffix元素会遮挡其兄弟项的点击热区，prefix与suffix设置为pointer-events:none;将点击事件传递给下层。

### 📝 更新日志

- fix(SideBar): 修复子项激活态时 `prefix`与`suffix` 内容遮挡相邻项的点击热区问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
