### PR TITLE
fix(tabbar): 修复tabbar红色气泡遮住了底部图标

### DIFF
--- a/src/badge/__test__/__snapshots__/demo.test.js.snap
+++ b/src/badge/__test__/__snapshots__/demo.test.js.snap
@@ -14,12 +14,6 @@ exports[`Badge Badge base demo works fine 1`] = `
       class="wrapper"
       content="消息"
       dot="{{true}}"
-      offset="{{
-        Array [
-          -4,
-          4,
-        ]
-      }}"
     />
     <t-badge
       class="wrapper"
@@ -66,7 +60,7 @@ exports[`Badge Badge base demo works fine 1`] = `
       count="8"
       offset="{{
         Array [
-          -8,
+          4,
         ]
       }}"
     />
@@ -75,7 +69,7 @@ exports[`Badge Badge base demo works fine 1`] = `
       count="2"
       offset="{{
         Array [
-          -2,
+          2,
           -2,
         ]
       }}"
@@ -193,7 +187,7 @@ exports[`Badge Badge theme demo works fine 1`] = `
       count="2"
       offset="{{
         Array [
-          -2,
+          2,
           -2,
         ]
       }}"
@@ -217,7 +211,7 @@ exports[`Badge Badge theme demo works fine 1`] = `
       count="2"
       offset="{{
         Array [
-          -2,
+          1,
           -2,
         ]
       }}"

--- a/src/badge/__test__/index.test.js
+++ b/src/badge/__test__/index.test.js
@@ -209,7 +209,6 @@ describe('badge', () => {
 
     const $count = comp.querySelector('.badge >>> .t-badge--basic');
     expect($count.dom.style.top).toBe('20em');
-    expect($count.dom.style.right).toBe('15px');
   });
 
   it(':offset number without unit', async () => {
@@ -229,6 +228,5 @@ describe('badge', () => {
 
     const $count = comp.querySelector('.badge >>> .t-badge--basic');
     expect($count.dom.style.top).toBe('29px');
-    expect($count.dom.style.right).toBe('16px');
   });
 });

--- a/src/badge/_example/base/index.wxml
+++ b/src/badge/_example/base/index.wxml
@@ -1,6 +1,6 @@
 <view class="demo-desc">红点徽标</view>
 <view class="demo-wrapper">
-  <t-badge dot offset="{{ [-4, 4] }}" class="wrapper" content="消息" />
+  <t-badge dot class="wrapper" content="消息" />
   <t-badge dot offset="{{ [1, -1] }}" class="wrapper">
     <t-icon name="notification" size="24" ariaLabel="通知" />
   </t-badge>
@@ -11,8 +11,8 @@
 
 <view class="demo-desc">数字徽标</view>
 <view class="demo-wrapper">
-  <t-badge count="8" content="消息" offset="{{ [-8] }}" class="wrapper" />
-  <t-badge count="2" offset="{{ [-2, -2] }}" class="wrapper">
+  <t-badge count="8" content="消息" offset="{{ [4] }}" class="wrapper" />
+  <t-badge count="2" offset="{{ [2, -2] }}" class="wrapper">
     <t-icon name="notification" size="24" ariaLabel="通知" />
   </t-badge>
   <t-badge count="8" offset="{{ [2, 2] }}" class="wrapper">

--- a/src/badge/_example/size/index.wxml
+++ b/src/badge/_example/size/index.wxml
@@ -1,11 +1,11 @@
 <view class="demo-desc">Large</view>
 
 <view class="block">
-  <t-avatar icon="user" size="large" badge-props="{{ {count: 8, size: 'large', offset: [-5, 7]} }}" />
+  <t-avatar icon="user" size="large" badge-props="{{ {count: 8, size: 'large', offset: [7, 7]} }}" />
 </view>
 
 <view class="demo-desc">Middle</view>
 
 <view class="block">
-  <t-avatar icon="user" badge-props="{{ {count: 8, offset: [-3, 5]} }}" />
+  <t-avatar icon="user" badge-props="{{ {count: 8, offset: [5, 5]} }}" />
 </view>

--- a/src/badge/_example/size/index.wxml
+++ b/src/badge/_example/size/index.wxml
@@ -1,11 +1,11 @@
 <view class="demo-desc">Large</view>
 
 <view class="block">
-  <t-avatar icon="user" size="large" badge-props="{{ {count: 8, size: 'large', offset: [7, 7]} }}" />
+  <t-avatar icon="user" size="large" badge-props="{{ {count: 8, size: 'large', offset: [-5, 7]} }}" />
 </view>
 
 <view class="demo-desc">Middle</view>
 
 <view class="block">
-  <t-avatar icon="user" badge-props="{{ {count: 8, offset: [5, 5]} }}" />
+  <t-avatar icon="user" badge-props="{{ {count: 8, offset: [-3, 5]} }}" />
 </view>

--- a/src/badge/_example/theme/index.wxml
+++ b/src/badge/_example/theme/index.wxml
@@ -7,14 +7,14 @@
 
 <view class="demo-desc">圆形徽标</view>
 <view class="demo-wrapper">
-  <t-badge count="2" offset="{{ [-2, -2] }}">
+  <t-badge count="2" offset="{{ [2, -2] }}">
     <t-icon name="notification" size="24" ariaLabel="通知" />
   </t-badge>
 </view>
 
 <view class="demo-desc">方形徽标</view>
 <view class="demo-wrapper">
-  <t-badge count="2" shape="square" offset="{{ [-2, -2] }}">
+  <t-badge count="2" shape="square" offset="{{ [1, -2] }}">
     <t-icon name="notification" size="24" ariaLabel="通知" />
   </t-badge>
 </view>

--- a/src/badge/badge.less
+++ b/src/badge/badge.less
@@ -104,9 +104,9 @@
   }
 
   &__content:not(:empty) + .t-has-count {
-    transform: translate(50%, -50%);
+    transform: translate(-50%, -50%);
     position: absolute;
-    right: 0;
+    left: 100%;
     top: 0;
   }
 

--- a/src/badge/badge.wxs
+++ b/src/badge/badge.wxs
@@ -26,7 +26,7 @@ var getBadgeStyles = function (props) {
     styleStr += 'background:' + props.color + ';';
   }
   if (props.offset[0]) {
-    styleStr += 'right:' + (hasUnit(props.offset[0].toString()) ? props.offset[0] : props.offset[0] + 'px') + ';';
+    styleStr += 'left: calc(100% + ' + (hasUnit(props.offset[0].toString()) ? props.offset[0] : props.offset[0] + 'px') + ');';
   }
   if (props.offset[1]) {
     styleStr += 'top:' + (hasUnit(props.offset[1].toString()) ? props.offset[1] : props.offset[1] + 'px') + ';';

--- a/src/tab-bar-item/tab-bar-item.less
+++ b/src/tab-bar-item/tab-bar-item.less
@@ -73,7 +73,7 @@
   }
 
   .@{prefix}-badge-class {
-    transform: translate(-30%, -30%) !important; // stylelint-disable-line
+    transform: translate(-30%, -30%); // stylelint-disable-line
   }
 
   &__text {

--- a/src/tab-bar-item/tab-bar-item.less
+++ b/src/tab-bar-item/tab-bar-item.less
@@ -73,7 +73,7 @@
   }
 
   .@{prefix}-badge-class {
-    transform: translate(50%, -10%) !important; // stylelint-disable-line
+    transform: translate(60%, -40%) !important; // stylelint-disable-line
   }
 
   &__text {

--- a/src/tab-bar-item/tab-bar-item.less
+++ b/src/tab-bar-item/tab-bar-item.less
@@ -73,7 +73,7 @@
   }
 
   .@{prefix}-badge-class {
-    transform: translate(60%, -40%) !important; // stylelint-disable-line
+    transform: translate(-30%, -30%) !important; // stylelint-disable-line
   }
 
   &__text {

--- a/src/tab-bar-item/tab-bar-item.less
+++ b/src/tab-bar-item/tab-bar-item.less
@@ -72,10 +72,6 @@
     // }
   }
 
-  .@{prefix}-badge-class {
-    transform: translate(-30%, -30%); // stylelint-disable-line
-  }
-
   &__text {
     display: flex;
     align-items: center;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2416

### 💡 需求背景和解决方案
问题：tabbar红色气泡遮住了底部图标
解决方案：修改tab-bar-item xx-badge-class的样式
修复前：
<img width="309" alt="企业微信截图_269a73cc-7a70-4376-8b0a-26c1088819f5" src="https://github.com/Tencent/tdesign-miniprogram/assets/16083809/80dc6e49-508a-418e-98a4-a3bb4c76c6ee">
修复后：
<img width="319" alt="企业微信截图_32e750b7-f807-4d1a-b554-52483735cbe2" src="https://github.com/Tencent/tdesign-miniprogram/assets/16083809/6b9092eb-ed4d-4c67-9660-6570f14636aa">

### 📝 更新日志

修复tabbar红色气泡遮住了底部图标

- fix(tabbar): 修复tabbar红色气泡遮住了底部图标

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
