### PR TITLE
fix(calendar): calendar组件自适应父容器宽

### DIFF
--- a/src/calendar/calendar.less
+++ b/src/calendar/calendar.less
@@ -12,6 +12,7 @@
 @calendar-item-disabled-color: var(--td-calendar-item-disabled-color, @font-gray-4);
 
 .@{prefix}-calendar {
+  width: inherit;
   position: relative;
   z-index: 9999;
   background: @calendar-bg-color;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2382

### 💡 需求背景和解决方案
问题：use-popup 设置为false情况，日历样式存在兼容问题
解决方案：组件自适应父容器宽

### 📝 更新日志

- fix(Calendar): 修复 `use-popup` 为 `false` 时，组件未适应父容器宽度的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
