### PR TITLE
fix: 修复checkbox onchange时无dateset数据

### DIFF
--- a/src/checkbox-group/checkbox-group.ts
+++ b/src/checkbox-group/checkbox-group.ts
@@ -73,8 +73,7 @@ export default class CheckBoxGroup extends SuperComponent {
       }
     },
 
-    updateValue({item,  checked, checkAll, indeterminate }) {
-      const { value } = item;
+    updateValue({value, checked, checkAll, item, indeterminate }) {
       let { value: newValue } = this.data;
       const { max } = this.data;
       const keySet = new Set(this.getChildren().map((item) => item.data.value));
@@ -138,7 +137,7 @@ export default class CheckBoxGroup extends SuperComponent {
         rect.indeterminate = this.$checkAll?.data.indeterminate;
       }
 
-      this.updateValue({ item, checked, ...rect });
+      this.updateValue({ ...item, checked, item, ...rect });
     },
 
     setCheckall() {

--- a/src/checkbox-group/checkbox-group.ts
+++ b/src/checkbox-group/checkbox-group.ts
@@ -73,7 +73,7 @@ export default class CheckBoxGroup extends SuperComponent {
       }
     },
 
-    updateValue({value, checked, checkAll, item, indeterminate }) {
+    updateValue({ value, checked, checkAll, item, indeterminate }) {
       let { value: newValue } = this.data;
       const { max } = this.data;
       const keySet = new Set(this.getChildren().map((item) => item.data.value));
@@ -104,7 +104,7 @@ export default class CheckBoxGroup extends SuperComponent {
         newValue.splice(index, 1);
       }
 
-      this._trigger('change', { value: newValue, dataset: item });
+      this._trigger('change', { value: newValue, context: item });
     },
 
     initWithOptions() {

--- a/src/checkbox-group/checkbox-group.ts
+++ b/src/checkbox-group/checkbox-group.ts
@@ -73,7 +73,8 @@ export default class CheckBoxGroup extends SuperComponent {
       }
     },
 
-    updateValue({ value, label, checked, checkAll, indeterminate }) {
+    updateValue({item,  checked, checkAll, indeterminate }) {
+      const { value } = item;
       let { value: newValue } = this.data;
       const { max } = this.data;
       const keySet = new Set(this.getChildren().map((item) => item.data.value));
@@ -104,7 +105,7 @@ export default class CheckBoxGroup extends SuperComponent {
         newValue.splice(index, 1);
       }
 
-      this._trigger('change', { value: newValue, dataset:{ value, label } });
+      this._trigger('change', { value: newValue, dataset: item });
     },
 
     initWithOptions() {
@@ -137,7 +138,7 @@ export default class CheckBoxGroup extends SuperComponent {
         rect.indeterminate = this.$checkAll?.data.indeterminate;
       }
 
-      this.updateValue({ ...item, checked, ...rect });
+      this.updateValue({ item, checked, ...rect });
     },
 
     setCheckall() {

--- a/src/checkbox-group/checkbox-group.ts
+++ b/src/checkbox-group/checkbox-group.ts
@@ -73,7 +73,7 @@ export default class CheckBoxGroup extends SuperComponent {
       }
     },
 
-    updateValue({ value, checked, checkAll, indeterminate }) {
+    updateValue({ value, label, checked, checkAll, indeterminate }) {
       let { value: newValue } = this.data;
       const { max } = this.data;
       const keySet = new Set(this.getChildren().map((item) => item.data.value));
@@ -104,7 +104,7 @@ export default class CheckBoxGroup extends SuperComponent {
         newValue.splice(index, 1);
       }
 
-      this._trigger('change', { value: newValue });
+      this._trigger('change', { value: newValue, dataset:{ value, label } });
     },
 
     initWithOptions() {

--- a/src/checkbox/README.en-US.md
+++ b/src/checkbox/README.en-US.md
@@ -28,7 +28,7 @@ value | String / Number / Boolean | - | value of checkbox。Typescript：`string
 
 name | params | description
 -- | -- | --
-change | `(checked: boolean)` | \-
+change | `(checked: boolean, context: { value: boolean|number|string, label: boolean|number|string })` | \-
 
 ### CheckboxGroup Props
 
@@ -46,7 +46,7 @@ default-value | Array | undefined | uncontrolled property。Typescript：`T` `ty
 
 name | params | description
 -- | -- | --
-change | `(value: CheckboxGroupValue)` | \-
+change | `(value: CheckboxGroupValue, context: { value: boolean|number|string, label: boolean|number|string })` | \-
 
 
 ### CSS Variables

--- a/src/checkbox/README.md
+++ b/src/checkbox/README.md
@@ -86,7 +86,7 @@ value | String / Number / Boolean | - | 多选框的值。TS 类型：`string \|
 
 名称 | 参数 | 描述
 -- | -- | --
-change | `(checked: boolean)` | 值变化时触发
+change | `(checked: boolean, {value: boolean|number|string, label: boolean|number|string })` | 值变化时触发
 
 ### Checkbox 外部样式类
 类名 | 说明

--- a/src/checkbox/README.md
+++ b/src/checkbox/README.md
@@ -86,7 +86,7 @@ value | String / Number / Boolean | - | 多选框的值。TS 类型：`string \|
 
 名称 | 参数 | 描述
 -- | -- | --
-change | `(checked: boolean, {value: boolean|number|string, label: boolean|number|string })` | 值变化时触发
+change | `(checked: boolean, context: { value: boolean|number|string, label: boolean|number|string })` | 值变化时触发。`context` 表示当前点击项内容。
 
 ### Checkbox 外部样式类
 类名 | 说明
@@ -113,7 +113,7 @@ default-value | Array | undefined | 选中值。非受控属性。TS 类型：`T
 
 名称 | 参数 | 描述
 -- | -- | --
-change | `(value: CheckboxGroupValue)` | 值变化时触发
+change | `(value: CheckboxGroupValue, context: { value: boolean|number|string, label: boolean|number|string })` | 值变化时触发。`context` 表示当前点击项内容。
 
 
 ### CSS 变量

--- a/src/checkbox/checkbox.ts
+++ b/src/checkbox/checkbox.ts
@@ -90,7 +90,7 @@ export default class CheckBox extends SuperComponent {
       if (parent) {
         parent.updateValue({ ...this.data, checked });
       } else {
-        this._trigger('change', { checked });
+        this._trigger('change', { dataset:this.dataset, checked });
       }
     },
   };

--- a/src/checkbox/checkbox.ts
+++ b/src/checkbox/checkbox.ts
@@ -83,14 +83,14 @@ export default class CheckBox extends SuperComponent {
       if (target === 'text' && contentDisabled) {
         return;
       }
-
+      const { value, label } = this.data;
       const checked = !this.data.checked;
       const parent = this.$parent;
 
       if (parent) {
         parent.updateValue({ ...this.data, checked });
       } else {
-        this._trigger('change', { dataset:this.dataset, checked });
+        this._trigger('change', { dataset:{ value, label }, checked });
       }
     },
   };

--- a/src/checkbox/checkbox.ts
+++ b/src/checkbox/checkbox.ts
@@ -90,7 +90,7 @@ export default class CheckBox extends SuperComponent {
       if (parent) {
         parent.updateValue({ ...this.data, checked });
       } else {
-        this._trigger('change', { dataset:{ value, label }, checked });
+        this._trigger('change', { context: { value, label }, checked });
       }
     },
   };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2395 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Checkbox):  `change` 事件新增参数 `context`，返回当前点击项内容

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√ ] 文档已补充或无须补充
- [√ ] 代码演示已提供或无须提供
- [√ ] TypeScript 定义已补充或无须补充
- [√ ] Changelog 已提供或无须提供
