### PR TITLE
fix(inputMaxCount): 解决设置最大长度时类型为number、digit不生效问题

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -109,11 +109,6 @@ export const getRect = function (context: any, selector: string, needAll: boolea
       .exec();
   });
 };
-
-const isDef = function (value: any): boolean {
-  return value !== undefined && value !== null;
-};
-
 export const isNumber = function (value) {
   return /^\d+(\.\d+)?$/.test(value);
 };
@@ -124,7 +119,9 @@ export const isNull = function (value: any): boolean {
 
 export const isUndefined = (value: any): boolean => typeof value === 'undefined';
 
-export const isNullOrUndefined = (value: any): boolean => isNull(value) || isUndefined(value);
+export const isDef = function (value: any): boolean {
+  return !isUndefined(value) && !isNull(value);
+};
 
 export const addUnit = function (value?: string | number): string | undefined {
   if (!isDef(value)) {
@@ -141,7 +138,7 @@ export const addUnit = function (value?: string | number): string | undefined {
  * @returns 当没有传入maxCharacter/maxLength 时返回字符串字符长度，当传入maxCharacter/maxLength时返回截取之后的字符串和长度。
  */
 export const getCharacterLength = (type: string, str: string, max?: number) => {
-  if (isNullOrUndefined(str) || str.length === 0) {
+  if (!isDef(str) || str.length === 0) {
     return {
       length: 0,
       characters: '',

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -114,10 +114,6 @@ const isDef = function (value: any): boolean {
   return value !== undefined && value !== null;
 };
 
-export const isOfType = function (type: string): (value: any) => boolean {
-  return (value: any) => typeof value === type;
-};
-
 export const isNumber = function (value) {
   return /^\d+(\.\d+)?$/.test(value);
 };
@@ -126,7 +122,7 @@ export const isNull = function (value: any): boolean {
   return value === null;
 };
 
-export const isUndefined = isOfType('undefined');
+export const isUndefined = (value: any) => typeof value === 'undefined';
 
 export const isNullOrUndefined = (value: any): boolean => isNull(value) || isUndefined(value);
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -114,9 +114,21 @@ const isDef = function (value: any): boolean {
   return value !== undefined && value !== null;
 };
 
+export const isOfType = function (type: string): (value: any) => boolean {
+  return (value: any) => typeof value === type;
+};
+
 export const isNumber = function (value) {
   return /^\d+(\.\d+)?$/.test(value);
 };
+
+export const isNull = function (value: any): boolean {
+  return value === null;
+};
+
+export const isUndefined = isOfType('undefined');
+
+export const isNullOrUndefined = (value: any): boolean => isNull(value) || isUndefined(value);
 
 export const addUnit = function (value?: string | number): string | undefined {
   if (!isDef(value)) {
@@ -133,7 +145,7 @@ export const addUnit = function (value?: string | number): string | undefined {
  * @returns 当没有传入maxCharacter/maxLength 时返回字符串字符长度，当传入maxCharacter/maxLength时返回截取之后的字符串和长度。
  */
 export const getCharacterLength = (type: string, str: string, max?: number) => {
-  if (str === null || str === undefined || str.length === 0) {
+  if (isNullOrUndefined(str) || str.length === 0) {
     return {
       length: 0,
       characters: '',

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -109,6 +109,7 @@ export const getRect = function (context: any, selector: string, needAll: boolea
       .exec();
   });
 };
+
 export const isNumber = function (value) {
   return /^\d+(\.\d+)?$/.test(value);
 };
@@ -133,12 +134,14 @@ export const addUnit = function (value?: string | number): string | undefined {
 
 /**
  * 计算字符串字符的长度并可以截取字符串。
- * @param str 传入字符串（maxcharacter条件下，一个汉字表示两个字符）
+ * @param char 传入字符串（maxcharacter条件下，一个汉字表示两个字符）
  * @param max 规定最大字符串长度
  * @returns 当没有传入maxCharacter/maxLength 时返回字符串字符长度，当传入maxCharacter/maxLength时返回截取之后的字符串和长度。
  */
-export const getCharacterLength = (type: string, str: string, max?: number) => {
-  if (!isDef(str) || str.length === 0) {
+export const getCharacterLength = (type: string, char: string | number, max?: number) => {
+  const str = String(char ?? '');
+
+  if (str.length === 0) {
     return {
       length: 0,
       characters: '',

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -122,7 +122,7 @@ export const isNull = function (value: any): boolean {
   return value === null;
 };
 
-export const isUndefined = (value: any) => typeof value === 'undefined';
+export const isUndefined = (value: any): boolean => typeof value === 'undefined';
 
 export const isNullOrUndefined = (value: any): boolean => isNull(value) || isUndefined(value);
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -133,7 +133,7 @@ export const addUnit = function (value?: string | number): string | undefined {
  * @returns 当没有传入maxCharacter/maxLength 时返回字符串字符长度，当传入maxCharacter/maxLength时返回截取之后的字符串和长度。
  */
 export const getCharacterLength = (type: string, str: string, max?: number) => {
-  if (!str || str.length === 0) {
+  if (str === null || str === undefined || str.length === 0) {
     return {
       length: 0,
       characters: '',

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -31,14 +31,15 @@ export default class Input extends SuperComponent {
     prefix,
     classPrefix: name,
     classBasePrefix: prefix,
-    excludeType: ['number', 'digit'],
+    excludeType: [],
     showClearIcon: true,
   };
 
   lifetimes = {
     ready() {
       const { value } = this.properties;
-      this.updateValue(value == null ? '' : value);
+      // 明确地检查null或undefined，防止0的情况被纳入
+      this.updateValue(value !== null && value !== undefined ? value : '');
     },
   };
 
@@ -85,7 +86,8 @@ export default class Input extends SuperComponent {
       } else {
         this.setData({
           value,
-          count: value ? String(value).length : 0,
+          // 确保值为0时正确设置count
+          count: value !== null && value !== undefined ? String(value).length : 0,
         });
       }
     },

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -1,7 +1,7 @@
 import { SuperComponent, wxComponent } from '../common/src/index';
 import config from '../common/config';
 import props from './props';
-import { getCharacterLength, calcIcon, isNullOrUndefined } from '../common/utils';
+import { getCharacterLength, calcIcon, isDef } from '../common/utils';
 
 const { prefix } = config;
 const name = `${prefix}-input`;
@@ -83,7 +83,7 @@ export default class Input extends SuperComponent {
       } else {
         this.setData({
           value,
-          count: !isNullOrUndefined(value) ? String(value).length : 0,
+          count: isDef(value) ? String(value).length : 0,
         });
       }
     },

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -74,7 +74,7 @@ export default class Input extends SuperComponent {
           value: characters,
           count: length,
         });
-      } else if (maxlength > 0 && !Number.isNaN(maxlength)) {
+      } else if (maxlength && maxlength > 0 && !Number.isNaN(maxlength)) {
         const { length, characters } = getCharacterLength('maxlength', value, maxlength);
         this.setData({
           value: characters,

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -37,7 +37,6 @@ export default class Input extends SuperComponent {
   lifetimes = {
     ready() {
       const { value } = this.properties;
-      // 明确地检查null或undefined，防止0的情况被纳入
       this.updateValue(value ?? '');
     },
   };
@@ -84,7 +83,6 @@ export default class Input extends SuperComponent {
       } else {
         this.setData({
           value,
-          // 确保值为0时正确设置count
           count: !isNullOrUndefined(value) ? String(value).length : 0,
         });
       }

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -85,7 +85,7 @@ export default class Input extends SuperComponent {
         this.setData({
           value,
           // 确保值为0时正确设置count
-          count: isNullOrUndefined(value) ? String(value).length : 0,
+          count: !isNullOrUndefined(value) ? String(value).length : 0,
         });
       }
     },

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -31,7 +31,6 @@ export default class Input extends SuperComponent {
     prefix,
     classPrefix: name,
     classBasePrefix: prefix,
-    excludeType: [],
     showClearIcon: true,
   };
 
@@ -69,15 +68,14 @@ export default class Input extends SuperComponent {
 
   methods = {
     updateValue(value) {
-      const { maxcharacter, maxlength, type } = this.properties;
-      const { excludeType } = this.data;
-      if (!excludeType.includes(type) && maxcharacter && maxcharacter > 0 && !Number.isNaN(maxcharacter)) {
+      const { maxcharacter, maxlength } = this.properties;
+      if (maxcharacter && maxcharacter > 0 && !Number.isNaN(maxcharacter)) {
         const { length, characters } = getCharacterLength('maxcharacter', value, maxcharacter);
         this.setData({
           value: characters,
           count: length,
         });
-      } else if (!excludeType.includes(type) && maxlength > 0 && !Number.isNaN(maxlength)) {
+      } else if (maxlength > 0 && !Number.isNaN(maxlength)) {
         const { length, characters } = getCharacterLength('maxlength', value, maxlength);
         this.setData({
           value: characters,

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -1,7 +1,7 @@
 import { SuperComponent, wxComponent } from '../common/src/index';
 import config from '../common/config';
 import props from './props';
-import { getCharacterLength, calcIcon } from '../common/utils';
+import { getCharacterLength, calcIcon, isNullOrUndefined } from '../common/utils';
 
 const { prefix } = config;
 const name = `${prefix}-input`;
@@ -38,7 +38,7 @@ export default class Input extends SuperComponent {
     ready() {
       const { value } = this.properties;
       // 明确地检查null或undefined，防止0的情况被纳入
-      this.updateValue(value !== null && value !== undefined ? value : '');
+      this.updateValue(value ?? '');
     },
   };
 
@@ -85,7 +85,7 @@ export default class Input extends SuperComponent {
         this.setData({
           value,
           // 确保值为0时正确设置count
-          count: value !== null && value !== undefined ? String(value).length : 0,
+          count: isNullOrUndefined(value) ? String(value).length : 0,
         });
       }
     },


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- https://github.com/Tencent/tdesign-miniprogram/issues/2103
- https://github.com/Tencent/tdesign-miniprogram/pull/2108
- https://github.com/Tencent/tdesign-miniprogram/issues/2368

### 💡 需求背景和解决方案

- 需求背景

之前的历史问题（<https://github.com/Tencent/tdesign-miniprogram/issues/2103>、<https://github.com/Tencent/tdesign-miniprogram/pull/2108>）的处理方式有误,导致出现了新的问题：<https://github.com/Tencent/tdesign-miniprogram/issues/2368>

- 解决方案

1、历史问题主要是null、undefined没有===严格判断，而是采用==和!等去判断空值，导致把0算进去了。因此用value !== null && value !== undefined 改成严格判断
2、去掉排除类型对长度设置的条件限制。

- 自测示例
<img width="1637" alt="image" src="https://github.com/Tencent/tdesign-miniprogram/assets/15664576/6220b1ca-dad1-4cd5-9314-88f1e48f4a4e">


### 📝 更新日志

- fix(Input): 修复 `type` 为 `digit`、`number`时，`maxlength` 和 `maxcharacter` 属性无效的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
