### PR TITLE
chore: update design path

### DIFF
--- a/site/plugin-tdoc/md-to-vue.ts
+++ b/site/plugin-tdoc/md-to-vue.ts
@@ -91,7 +91,7 @@ function customRender({ source, file, md }: any) {
 
   // 设计指南内容 不展示 design Tab 则不解析
   if (pageData.isComponent && pageData.tdDocTabs.some((item) => item.tab === 'design')) {
-    const designDocPath = path.resolve(__dirname, `../../src/_common/docs/miniprogram/design/${componentName}.md`);
+    const designDocPath = path.resolve(__dirname, `../../src/_common/docs/mobile/design/${componentName}.md`);
 
     if (fs.existsSync(designDocPath)) {
       const designMd = fs.readFileSync(designDocPath, 'utf-8');


### PR DESCRIPTION
设计指南更新为 `_common/docs/mobile/design` 路径，后期子仓库 `_common/docs/miniprogram` 文件夹可直接移除