### PR TITLE
fix(image.viewer.ts): 修复ImageViewer公共组件对纵图处理不当导致图片被裁剪的问题

### DIFF
--- a/src/image-viewer/image-viewer.ts
+++ b/src/image-viewer/image-viewer.ts
@@ -105,12 +105,24 @@ export default class ImageViewer extends SuperComponent {
           },
         };
       }
+
+      // 图片的高大于宽（纵向图），设定高度为100vh，宽度自适应，且确保宽度不超过屏幕宽度
+      const scaledHeight = ratio * windowHeight * 2;
+      if (scaledHeight < windowWidth) {
+        return {
+          styleObj: {
+            width: `${scaledHeight}rpx`,
+            height: '100vh',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          },
+        };
+      }
+      // 当通过高度计算的图片宽度超过屏幕宽度时, 以屏幕宽度为基准, 重新计算高度
       return {
         styleObj: {
-          width: `${ratio * windowHeight * 2}rpx`,
-          height: '100vh',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
+          width: '100vw',
+          height: `${(windowWidth / imageWidth) * imageHeight * 2}rpx`,
         },
       };
     },


### PR DESCRIPTION
使用者提出issue,反馈ImageViewer 图片预览没有设置宽高限制的情况下，图片被截断了,特此修复了公共组件中对纵图处理不当导致图片被裁剪的问题

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2560 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
https://github.com/Tencent/tdesign-miniprogram/issues/2560
-->

### 💡 需求背景和解决方案
**需求背景**：使用者提出issue,反馈ImageViewer 图片预览没有设置宽高限制的情况下，图片被截断了
**问题定位**：经过通过对多种图片，尤其是该issue中的图片的测试验证发现，该公共组件中对纵图的处理方式不当，导致纵图的宽不能很好的显示而被裁剪。
**解决方案**：优化纵图宽高计算逻辑，使纵图优雅完好的显示。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
