### PR TITLE
fix: add script for m2w

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,5 +10,11 @@
       "request": "launch",
       "type": "node-terminal"
     },
+    {
+      "command": "cd _example && npx m2w build",
+      "name": "npx m2w build",
+      "request": "launch",
+      "type": "node-terminal"
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "generate": "gulp generate --gulpfile script/gulpfile.js --cwd ./",
     "changelog": "node script/generate-changelog.js",
     "robot": "publish-cli robot-msg",
-    "qrcode": "node script/qrcode/index.js"
+    "qrcode": "node script/qrcode/index.js",
+    "postinstall": "$(npm bin)/patch-package --patch-dir ./node_modules/@tencent/m2w/patches"
   },
   "author": "tdesign",
   "license": "MIT",


### PR DESCRIPTION
背景：m2w 构建失败
原因：wxss文件大小超出数据量，导致进程直接终止

方案：由于m2w内携带的 patch 文件无法影响到外层 miniprogram-compiler包，特此新增 `postinstall` 脚本为依赖的`miniprogram-compiler`包注入补丁
