### PR TITLE
fix(Demo): update demo

### DIFF
--- a/src/avatar/__test__/__snapshots__/demo.test.js.snap
+++ b/src/avatar/__test__/__snapshots__/demo.test.js.snap
@@ -35,7 +35,7 @@ exports[`Avatar Avatar badge-avatar demo works fine 1`] = `
       Object {
         "dot": true,
         "offset": Array [
-          4,
+          0,
           4,
         ],
       }
@@ -48,7 +48,7 @@ exports[`Avatar Avatar badge-avatar demo works fine 1`] = `
       Object {
         "count": 8,
         "offset": Array [
-          6,
+          -6,
           6,
         ],
       }
@@ -63,7 +63,7 @@ exports[`Avatar Avatar badge-avatar demo works fine 1`] = `
       Object {
         "count": 12,
         "offset": Array [
-          6,
+          -6,
           6,
         ],
       }

--- a/src/avatar/_example/badge-avatar/index.wxml
+++ b/src/avatar/_example/badge-avatar/index.wxml
@@ -1,8 +1,8 @@
-<t-avatar class="avatar-example" image="{{image}}" badge-props="{{ {dot: true, offset: [4, 4] } }}" />
+<t-avatar class="avatar-example" image="{{image}}" badge-props="{{ {dot: true, offset: [0, 4] } }}" />
 <t-avatar
   class="avatar-example"
   t-class-content="external-class-content"
-  badge-props="{{ {count: 8, offset: [6, 6] } }}"
+  badge-props="{{ {count: 8, offset: [-6, 6] } }}"
   >A</t-avatar
 >
-<t-avatar class="avatar-example" icon="user" badge-props="{{ {count: 12,  offset: [6, 6] } }}" />
+<t-avatar class="avatar-example" icon="user" badge-props="{{ {count: 12,  offset: [-6, 6] } }}" />

--- a/src/tabs/__test__/__snapshots__/demo.test.js.snap
+++ b/src/tabs/__test__/__snapshots__/demo.test.js.snap
@@ -355,8 +355,8 @@ exports[`Tabs Tabs with-badge demo works fine 1`] = `
         Object {
           "dot": true,
           "offset": Array [
-            "-10rpx",
-            "4rpx",
+            "4px",
+            "4px",
           ],
         }
       }}"
@@ -368,8 +368,8 @@ exports[`Tabs Tabs with-badge demo works fine 1`] = `
         Object {
           "count": 8,
           "offset": Array [
-            "-16rpx",
-            "8rpx",
+            "8px",
+            "8px",
           ],
         }
       }}"

--- a/src/tabs/_example/with-badge/index.wxml
+++ b/src/tabs/_example/with-badge/index.wxml
@@ -1,5 +1,5 @@
 <t-tabs defaultValue="{{0}}">
-  <t-tab-panel label="选项" value="0" badge-props="{{ { dot: true, offset: ['-10rpx', '4rpx'] } }}" />
-  <t-tab-panel label="选项" value="1" badge-props="{{ { count: 8, offset: ['-16rpx', '8rpx'] } }}" />
+  <t-tab-panel label="选项" value="0" badge-props="{{ { dot: true, offset: ['4px', '4px'] } }}" />
+  <t-tab-panel label="选项" value="1" badge-props="{{ { count: 8, offset: ['8px', '8px'] } }}" />
   <t-tab-panel label="选项" value="2" />
 </t-tabs>


### PR DESCRIPTION
- 处理 Avatar、Tabs 组件示例中徽标位置不对的问题

视觉稿：
<img width="780" alt="截屏2024-03-25 19 02 26" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/7286a59e-b254-4eec-a832-89a12347f40e">

<img width="474" alt="截屏2024-03-25 19 02 15" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/c4a7b744-af54-4446-9dc8-f1ce4062c8dd">
