### PR TITLE
fix(checkbox-group): value in options object does not support number type

### DIFF
--- a/src/checkbox-group/checkbox-group.ts
+++ b/src/checkbox-group/checkbox-group.ts
@@ -109,7 +109,7 @@ export default class CheckBoxGroup extends SuperComponent {
       } else if (checked) {
         newValue = newValue.concat(value);
       } else {
-        const index = newValue.findIndex((v: string) => v === value);
+        const index = newValue.findIndex((v: string | number) => v === value);
         newValue.splice(index, 1);
       }
 

--- a/src/checkbox-group/checkbox-group.wxml
+++ b/src/checkbox-group/checkbox-group.wxml
@@ -7,7 +7,7 @@
       class="{{prefix}}-checkbox-option"
       data-item="{{item}}"
       label="{{item.label || item.text || ''}}"
-      value="{{item.value || ''}}"
+      value="{{item.value == null ? '' : item.value}}"
       block="{{item.block || true}}"
       check-all="{{item.checkAll || false}}"
       checked="{{item.checked || false}}"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fix #2726 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CheckboxGroup): `options` 对象中 `value` 不支持 `number` 类型

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
