### PR TITLE
fix(Progress): using component-level css token

### DIFF
--- a/src/common/style/base.less
+++ b/src/common/style/base.less
@@ -1,4 +1,2 @@
-@import './theme/_light.less'; // 保证用户在不单独引入 src/common/style/theme/_index.less，浅色模式正常。2.x可移除，官网文档“快速开始”补充引入less说明
-
 // 变量
 @import './_variables.less';

--- a/src/progress/progress.less
+++ b/src/progress/progress.less
@@ -45,6 +45,8 @@
 
 // 进度条基本样式
 .@{progress} {
+  --td-progress-track-bg-color: @bg-color-component;
+
   &__inner {
     position: relative;
     height: 100%;

--- a/src/progress/progress.wxml
+++ b/src/progress/progress.wxml
@@ -76,7 +76,7 @@
       aria-label="{{ ariaLabel || (isIOS ? this.getIOSAriaLabel(status) : this.getAndroidAriaLabel(status))  }}"
       aria-live="polite"
       class="{{classPrefix}}__canvas--circle"
-      style="background-image: conic-gradient( {{colorCircle || this.STATUS_COLOR[status] || '#0052d9'}} {{computedProgress}}%, {{bgColorBar || 'var(--td-bg-color-component)'}} 0%);"
+      style="background-image: conic-gradient( {{colorCircle || this.STATUS_COLOR[status] || '#0052d9'}} {{computedProgress}}%, {{bgColorBar || 'var(--td-progress-track-bg-color)'}} 0%);"
     >
       <view
         class="{{classPrefix}}__canvas--inner {{prefix}}-class-bar"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2748 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：
1.3.0版，组件实现中存在直接使用全局变量，如progress组件使用--td-bg-color-component变量来响应深/浅模式的切换，但是在组件中--td-bg-color-component变量只声明未赋值，如果没有引入相关的样式文件，则会导致出现#2710问题。因此在1.3.1中为了保证用户在不单独引入 src/common/style/theme/_index.less 样式文件的情况下浅色模式正常，为每个组件都单独引入了_light.less，带来两个问题： 1.导致组件样式中都存在一个page{}选择器，导致控制台告警，该问题不影响功能使用，可忽略。（个人认为page选择器比较特殊，应该允许正常使用，移除page选择器带来的告警问题），2. 问题#2748 ，比较严重，需要处理。

方案：组件中使用组件级 css variable，并赋予初始值，避免使用全局变量。 建议用户单独引入src/common/style/theme/_index.less 文件， 该文件中包含，
<img width="328" alt="截屏2024-05-08 11 39 22" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/da369152-9674-4bea-9380-ee0ae29f4447">，完整的design token，方便进行二次主题定制。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Progress): 使用组件级 css variables

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
