### PR TITLE
chore(Navbar): revert to using px units

### DIFF
--- a/src/navbar/__test__/__snapshots__/index.test.js.snap
+++ b/src/navbar/__test__/__snapshots__/index.test.js.snap
@@ -40,7 +40,7 @@ exports[`navbar :base 2`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide-animation class t-class"
-      style="--td-navbar-padding-top: 36rpx; --td-navbar-right: 170rpx; --td-navbar-capsule-height: 58rpx; --td-navbar-capsule-width: 158rpx; --td-navbar-height: 170rpx;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -75,7 +75,7 @@ exports[`navbar :base 3`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide class t-class"
-      style="--td-navbar-padding-top: 36rpx; --td-navbar-right: 170rpx; --td-navbar-capsule-height: 58rpx; --td-navbar-capsule-width: 158rpx; --td-navbar-height: 170rpx;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -110,7 +110,7 @@ exports[`navbar :fixed 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--visible-animation class t-class"
-      style="--td-navbar-padding-top: 36rpx; --td-navbar-right: 170rpx; --td-navbar-capsule-height: 58rpx; --td-navbar-capsule-width: 158rpx; --td-navbar-height: 170rpx;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -145,7 +145,7 @@ exports[`navbar :menu button 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed  class t-class"
-      style="--td-navbar-padding-top: 36rpx; --td-navbar-right: 775rpx; --td-navbar-capsule-height: 18rpx; --td-navbar-capsule-width: 72rpx; --td-navbar-height: -18rpx;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 428px; --td-navbar-capsule-height: 10px; --td-navbar-capsule-width: 40px; --td-navbar-height: -10px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"

--- a/src/navbar/_example/back-home/index.wxss
+++ b/src/navbar/_example/back-home/index.wxss
@@ -18,6 +18,6 @@
   top: 50%;
   transform: translateY(-50%);
   width: 1px;
-  height: 36rpx;
+  height: 18px;
   background: #e7e7e7;
 }

--- a/src/navbar/_example/img/index.wxss
+++ b/src/navbar/_example/img/index.wxss
@@ -1,4 +1,4 @@
 .custom-image {
-  height: 48rpx;
-  width: 174rpx;
+  height: 24px;
+  width: 87px;
 }

--- a/src/navbar/_example/left-title/index.wxss
+++ b/src/navbar/_example/left-title/index.wxss
@@ -1,6 +1,6 @@
 .custom-title {
-  margin-left: 16rpx;
-  font-size: 36rpx;
+  margin-left: 8px;
+  font-size: 18px;
   font-weight: 600;
 }
 
@@ -16,7 +16,7 @@
 
 .left-text {
   display: block;
-  margin-left: 8rpx;
+  margin-left: 4px;
   font-size: 16px;
 }
 

--- a/src/navbar/_example/search/index.wxss
+++ b/src/navbar/_example/search/index.wxss
@@ -1,4 +1,8 @@
 .search-box {
-  --td-search-height: 64rpx;
+  --td-search-height: 32px;
   width: 252px;
+}
+
+page {
+  --td-search-font-size: 18px;
 }

--- a/src/navbar/_example/skyline/navbar.less
+++ b/src/navbar/_example/skyline/navbar.less
@@ -14,3 +14,8 @@
 .base .block {
   margin: 48rpx 0;
 }
+
+.demo {
+  --td-navbar-bg-color: var(--td-navbar-bg-color-example);
+  --td-navbar-color: var(--td-navbar-color-example);
+}

--- a/src/navbar/_example/skyline/navbar.wxml
+++ b/src/navbar/_example/skyline/navbar.wxml
@@ -1,5 +1,5 @@
 <view class="skyline">
-  <t-navbar class="block" title="NavBar" left-arrow />
+  <t-navbar title="NavBar" left-arrow />
   <scroll-view scroll-y type="list" class="scroll-view">
     <view class="demo">
       <view class="demo-title">NavBar 导航栏</view>

--- a/src/navbar/navbar.less
+++ b/src/navbar/navbar.less
@@ -3,24 +3,24 @@
 
 @navbar-color: var(--td-navbar-color, @text-color-primary);
 @navbar-bg-color: var(--td-navbar-bg-color, @bg-color-container);
-@navbar-height: var(--td-navbar-height, 96rpx);
+@navbar-height: var(--td-navbar-height, 48px);
 @navbar-right: var(
   --td-navbar-right,
-  190rpx
+  95px
 ); // 默认右上角胶囊按钮宽度，组件会在初始化时尝试自动获取胶囊按钮宽度并覆写该值
 @navbar-padding-top: var(
   --td-navbar-padding-top,
-  40rpx
+  20px
 ); // 导航栏顶部间距，组件会在初始化时尝试取右侧系统胶囊位置进行覆盖
-@navbar-title-font-size: var(--td-navbar-title-font-size, 36rpx);
+@navbar-title-font-size: var(--td-navbar-title-font-size, 18px);
 @navbar-title-font-weight: var(--td-navbar-title-font-weight, 600);
-@navbar-left-arrow-size: var(--td-navbar-left-arrow-size, 48rpx);
+@navbar-left-arrow-size: var(--td-navbar-left-arrow-size, 24px);
 
 // capsule
 @navbar-capsule-border-color: var(--td-navbar-capsule-border-color, @border-level-1-color);
-@navbar-capsule-border-radius: var(--td-navbar-capsule-border-radius, 32rpx);
-@navbar-capsule-width: var(--td-navbar-capsule-width, 176rpx);
-@navbar-capsule-height: var(--td-navbar-capsule-height, 64rpx);
+@navbar-capsule-border-radius: var(--td-navbar-capsule-border-radius, 16px);
+@navbar-capsule-width: var(--td-navbar-capsule-width, 88px);
+@navbar-capsule-height: var(--td-navbar-capsule-height, 32px);
 // var(--capsule-height)
 
 .@{prefix}-navbar {
@@ -114,7 +114,7 @@
   }
 
   &__center {
-    font-size: 36rpx;
+    font-size: 18px;
     text-align: center;
     position: absolute;
     bottom: 0;

--- a/src/navbar/navbar.ts
+++ b/src/navbar/navbar.ts
@@ -74,16 +74,15 @@ export default class Navbar extends SuperComponent {
     wx.getSystemInfo({
       success: (res) => {
         const boxStyleList = [];
-        const { windowWidth, statusBarHeight } = wx.getSystemInfoSync();
-        const px2rpx = (v: number) => Math.round((v * 750) / (windowWidth >= 750 ? 750 / 2 : windowWidth));
+        const { statusBarHeight } = wx.getSystemInfoSync();
 
-        boxStyleList.push(`--td-navbar-padding-top: ${px2rpx(statusBarHeight)}rpx`);
+        boxStyleList.push(`--td-navbar-padding-top: ${statusBarHeight}px`);
         if (rect && res?.windowWidth) {
-          boxStyleList.push(`--td-navbar-right: ${px2rpx(res.windowWidth - rect.left)}rpx`); // 导航栏右侧小程序胶囊按钮宽度
+          boxStyleList.push(`--td-navbar-right: ${res.windowWidth - rect.left}px`); // 导航栏右侧小程序胶囊按钮宽度
         }
-        boxStyleList.push(`--td-navbar-capsule-height: ${px2rpx(rect.height)}rpx`); // 胶囊高度
-        boxStyleList.push(`--td-navbar-capsule-width: ${px2rpx(rect.width)}rpx`); // 胶囊宽度
-        boxStyleList.push(`--td-navbar-height: ${px2rpx((rect.top - statusBarHeight) * 2 + rect.height)}rpx`);
+        boxStyleList.push(`--td-navbar-capsule-height: ${rect.height}px`); // 胶囊高度
+        boxStyleList.push(`--td-navbar-capsule-width: ${rect.width}px`); // 胶囊宽度
+        boxStyleList.push(`--td-navbar-height: ${(rect.top - statusBarHeight) * 2 + rect.height}px`);
         this.setData({
           boxStyle: `${boxStyleList.join('; ')}`,
         });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
### 背景
在不同尺寸设备中右侧胶囊大小均一致，为适配右侧胶囊大小，Navbar 组件恢复使用 px 单位，垂直方向上（容器高度、字体大小、上下边距）也建议改用 px。

<img width="321" alt="截屏2024-05-16 14 48 53" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/0551f305-e825-4d84-a90b-1515b5fd56f0">
<img width="428" alt="截屏2024-05-16 14 49 08" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/73a8a5a7-dd02-41a0-9996-ce0d227f093d">
<img width="374" alt="截屏2024-05-16 14 48 39" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/d845cfd6-b978-4769-b416-5e2f7ff3ca80">
<img width="766" alt="截屏2024-05-16 14 49 42" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/5854fb3b-9baf-4d7c-bcd3-84588076e417">
<img width="833" alt="截屏2024-05-16 14 49 27" src="https://github.com/Tencent/tdesign-miniprogram/assets/51158141/fd695e11-9343-4e45-9d1c-266c817e190c">


<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Navbar):  为适配右侧胶囊尺寸，恢复使用 `px` 单位

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
