### PR TITLE
fix(tabs): 修复在 Skyline 模式下组件不能正常使用的问题

### DIFF
--- a/src/tabs/tabs.wxml
+++ b/src/tabs/tabs.wxml
@@ -23,6 +23,7 @@
         scroll-with-animation
         enable-passive
         show-scrollbar="{{false}}"
+        type="list"
         bind:scroll="onScroll"
       >
         <view class="{{_.cls(classPrefix + '__nav', [placement])}}" aria-role="tablist">


### PR DESCRIPTION
fix the issue with the tabs component under Skyline

fix #2786

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-miniprogram/issues/2786

### 💡 需求背景和解决方案

- tabs 组件依赖小程序内置的 `scroll-view` 组件，而在 Skyline 渲染模式下 `scroll-view` 组件需要增加 `type` 属性才可以正常运作， 这里加上了 `type="list"`。
- 关于 scroll-view 在 skyline 的属性参见：['说明文档'](https://developers.weixin.qq.com/miniprogram/dev/component/scroll-view.html#Skyline-%E7%89%B9%E6%9C%89%E5%B1%9E%E6%80%A7)

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复在 Skyline 模式下组件不能正常使用的问题 ...



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
