### PR TITLE
fix(Icon): supplementary image width and height

### DIFF
--- a/src/icon/icon.less
+++ b/src/icon/icon.less
@@ -14,9 +14,8 @@
 
 .@{prefix}-icon {
   &--image {
-    // 2.x 建议移除该wrapper
-    width: 100%;
-    height: 100%;
+    width: 40rpx;
+    height: 40rpx;
   }
 
   &__image {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2797 

问题背景：
1. 1.4.0版本name传入链接时必须指定size，否则自定义图片的icon不能正常显示
2. 如果icon组件是其他组件（如cell）的子组件，且需要定义icon为图片时，给其传值就只能传object
需求：像1.3.x版本一样。支持直接给icon传图片链接，也能正常显示

问题分析：icon组件的size属性默认为inherit本身是比较合适的，1.4.0版中icon组件为适配skyline将1em变更为100%，由一个具体宽高值变成需要依赖父容器宽高，带来的问题就是图片资源必须要指定宽高（通过传入size属性、覆盖组件样式等方式处理）。

最终方案：和设计师讨论之后，决定将图片资源的默认宽高取 40rpx， 继续保留icon组件的size属性默认值为inherit。

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
4. 列出最终的 API 实现和用法。
5. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Icon): 补充图片资源宽高

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
