### PR TITLE
chore: added npm package entry file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   moduleFileExtensions: ['js', 'ts'],
   moduleNameMapper: {
     '^tdesign-miniprogram/(.*)': '<rootDir>/src/$1',
+    '^tdesign-miniprogram': '<rootDir>/src/index',
     '^@behaviors/(.*)': '<rootDir>/example/behaviors/$1',
   },
   testMatch: ['<rootDir>/src/**/__test__/**/*.test.{js,ts}'],

--- a/src/action-sheet/_example/align/index.js
+++ b/src/action-sheet/_example/align/index.js
@@ -1,4 +1,4 @@
-import ActionSheet, { ActionSheetTheme } from 'tdesign-miniprogram/action-sheet/index';
+import { ActionSheet, ActionSheetTheme } from 'tdesign-miniprogram';
 
 Component({
   methods: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export { default as Dialog } from './dialog/index';
+export { default as Message } from './message/index';
+export { default as Toast } from './toast/index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { default as ActionSheet, ActionSheetTheme } from './action-sheet/index';
 export { default as Dialog } from './dialog/index';
 export { default as Message } from './message/index';
 export { default as Toast } from './toast/index';

--- a/src/toast/_example/base/index.js
+++ b/src/toast/_example/base/index.js
@@ -1,6 +1,6 @@
 import SkylineBehavior from '@behaviors/skyline.js';
 
-import Toast from 'tdesign-miniprogram/toast/index';
+import { Toast } from 'tdesign-miniprogram';
 
 Component({
   behaviors: [SkylineBehavior],


### PR DESCRIPTION
### 背景
目前 package.json 中 main [指定的入口文件并不存在。实际上，在小程序中，我们都是明确地指定要引用的组件文件，而不是默认地引用main属性指向的文件，所以这个属性的作用有限。当然也不排除，部分场景的小程序npm包必须指定main，详见[NPM](https://developers.weixin.qq.com/miniprogram/dev/devtools/npm.html)

### 方案
补充入口文件，对 plugin 组件来说可以简化引入，

```js
import Toast from 'tdesign-miniprogram/toast/index'

// 简化 
 import { Toast } from 'tdesign-miniprogram';
```

