### PR TITLE
fix(CheckTag): fix checked attribute type error

### DIFF
--- a/src/check-tag/props.ts
+++ b/src/check-tag/props.ts
@@ -8,12 +8,12 @@ import { TdCheckTagProps } from './type';
 const props: TdCheckTagProps = {
   /** 标签选中的状态，默认风格（theme=default）才有选中态 */
   checked: {
-    type: Boolean,
+    type: null,
     value: undefined,
   },
   /** 标签选中的状态，默认风格（theme=default）才有选中态，非受控属性 */
   defaultChecked: {
-    type: Boolean,
+    type: null,
     value: undefined,
   },
   /** 标签是否可关闭 */


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2870
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
### 为什么组件内部 `checked`属性类型必须为 null
https://github.com/Tencent/tdesign-miniprogram/blob/92e38d0df796dec8cb3f58c768c5fc031d64c7cb/src/common/src/instantiationDecorator.ts#L126
原因分析有以下几点：
- 受到受控和非受控能力影响
- 受控属性优先级大于非受控属性。checked > defaultChecked
- 属性值类型会被强转为指定的属性类型。如a的实际值会被转为false 
```js  
properties: {
    a: {
      type: Boolean,
      value: undefined
    }
  }
 ```
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CheckTag):  更正组件内部 `checked`属性类型

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
