### PR TITLE
fix(Overlay): resolved visible attr is invalid

### DIFF
--- a/src/overlay/props.ts
+++ b/src/overlay/props.ts
@@ -31,11 +31,6 @@ const props: TdOverlayProps = {
     type: String,
     value: '',
   },
-  /** 是否展示 */
-  visible: {
-    type: Boolean,
-    value: false,
-  },
   /** 遮罩层级 */
   zIndex: {
     type: Number,

--- a/src/picker/__test__/__snapshots__/index.test.js.snap
+++ b/src/picker/__test__/__snapshots__/index.test.js.snap
@@ -167,7 +167,17 @@ exports[`picker :base 1`] = `
     <t-overlay
       id="popup-overlay"
       bind:tap="handleOverlayClick"
-    />
+    >
+      <wx-view
+        ariaLabel="关闭"
+        ariaRole="button"
+        class="t-overlay t-fade-enter t-fade-enter-active class"
+        style="--td-overlay-transition-duration:300ms; z-index:11000; top:0px;"
+        bind:tap="handleClick"
+        catch:touchmove="noop"
+        bind:transitionend="onTransitionEnd"
+      />
+    </t-overlay>
   </t-popup>
 </t-picker>
 `;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2885
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
### 原因
在微信小程序中，properties 属性的优先级要高于 behaviors 中的同名属性。

当组件使用了behaviors时，behaviors中定义的属性和方法会被合并到组件中。如果组件本身已经定义了与behaviors中同名的属性或方法，那么组件自身的属性或方法会覆盖behaviors中的同名属性或方法。因此，properties中的visible属性优先级高于behaviors的visible，导致遮罩失效。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Overlay): 修复遮罩失效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
