### PR TITLE
fix(Input): fallback to using tap event

### DIFF
--- a/src/input/__test__/__snapshots__/index.test.js.snap
+++ b/src/input/__test__/__snapshots__/index.test.js.snap
@@ -67,7 +67,7 @@ exports[`input props : clearable && label && suffix 1`] = `
         />
         <wx-view
           class="t-input__wrap--clearable-icon"
-          bind:touchstart="clearInput"
+          bind:tap="clearInput"
         >
           <t-icon
             class=""

--- a/src/input/__test__/index.test.js
+++ b/src/input/__test__/index.test.js
@@ -190,7 +190,7 @@ describe('input', () => {
       comp.attach(document.createElement('parent-wrapper'));
 
       const clearable = comp.querySelector('.base >>> .t-input__wrap--clearable-icon');
-      clearable.dispatchEvent('touchstart');
+      clearable.dispatchEvent('tap');
       await simulate.sleep(0);
       expect(handleClear.mock.calls[0][0].detail).toStrictEqual({});
     });

--- a/src/input/input.wxml
+++ b/src/input/input.wxml
@@ -70,7 +70,7 @@
       <view
         wx:if="{{_clearIcon && value.length > 0 && showClearIcon}}"
         class="{{classPrefix}}__wrap--clearable-icon"
-        bind:touchstart="clearInput"
+        bind:tap="clearInput"
       >
         <template
           is="icon"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2937 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

背景： wxif + bindtouchstart，点击该事件后dom销毁，当前页面上的其他bindtap事件无效， bindtouchstart事件正常。代码片段：https://developers.weixin.qq.com/s/noGD5mmY76Sc
原因：根本原因是 touchstart 阶段就删除了节点，导致 touchend 没触发
解决方案：两个方向：1.不删除节点（wxif改用hidden）；2.改用tap/touchend 删除节点
方案效果对比：ios
render|方案| 事件效果| 交互效果
--|-- | -- | -- 
webview|-|正常|input内容清除，保持聚焦状态，软键盘不收起
skyline|-|失效|input内容清除，软键盘收起
webview|wxif改用hidden|正常|input内容清除，软键盘收起
skyline|wxif改用hidden|正常|input内容清除，软键盘收起
webview|改用tap|正常|input内容清除，软键盘收起
skyline|改用tap|正常|input内容清除，软键盘收起
webview|改用touchend|正常|input内容清除，软键盘收起
skyline|改用touchend|正常|input内容清除，软键盘收起


### 历史变更记录：
在 #1702 中，为达到"清空内容时，软键盘不收起"的交互效果，从 tap 改用 touchstart，当前为了保证skyline render环境下的正常使用和交互效果一致，重新改用 tap，webview环境下的交互效果会变更为“清空内容时，软键盘收起”。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复Skyline下点击清除图标时页面上 `bindtap` 无效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
