### PR TITLE
fix(cell): reset lastChild in cell group when a child is unlinked

### DIFF
--- a/src/cell-group/cell-group.ts
+++ b/src/cell-group/cell-group.ts
@@ -15,6 +15,9 @@ export default class CellGroup extends SuperComponent {
       linked() {
         this.updateLastChid();
       },
+      unlinked() {
+        this.updateLastChid();
+      },
     },
   };
 


### PR DESCRIPTION
reset lastChild in cell group when a child is unlinked

fix #3052

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#3052 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在cell group中有cell被移除时重新计算lastChild来更新border的显示和隐藏
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(CellGroup): 修复子项移除时，最后一项下边框显示错误

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
