### PR TITLE
feat(slider): fix incorrect dot pos caused by repeated init

### DIFF
--- a/src/slider/README.md
+++ b/src/slider/README.md
@@ -101,7 +101,7 @@ t-class-cursor | 游标样式类
 
 ## FAQ
 
-当 slider 外层使用 `hidden` 包裹，需要在 `hidden = false` 时，重新调用组件的 `init` 方法，才能正常渲染。如下：
+当 slider 外层使用 `hidden` 包裹，需要在 `hidden = false` 时，重新调用组件的 `init` 方法，才能正常渲染（在t-popup/t-dialog中同理）。如下：
 
 ```html
 <t-slider id="slider" />

--- a/src/slider/slider.ts
+++ b/src/slider/slider.ts
@@ -28,6 +28,7 @@ type dataType = {
   prefix: string;
   isVisibleToScreenReader: boolean;
   identifier: number[];
+  __inited: boolean;
 };
 
 interface boundingClientRect {
@@ -45,6 +46,10 @@ export default class Slider extends SuperComponent {
     `${prefix}-class-bar-disabled`,
     `${prefix}-class-cursor`,
   ];
+
+  options = {
+    pureDataPattern: /^__/,
+  };
 
   properties = props;
 
@@ -76,6 +81,7 @@ export default class Slider extends SuperComponent {
     prefix,
     isVisibleToScreenReader: false,
     identifier: [-1, -1],
+    __inited: false,
   };
 
   observers = {
@@ -218,6 +224,7 @@ export default class Slider extends SuperComponent {
   }
 
   async init() {
+    if (this.data.__inited) return;
     const line: boundingClientRect = await getRect(this, '#sliderLine');
     const { blockSize } = this.data;
     const { theme, vertical } = this.properties;
@@ -238,6 +245,7 @@ export default class Slider extends SuperComponent {
       maxRange,
       initialLeft,
       initialRight,
+      __inited: true,
     });
     this.bus.emit('initial');
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3083 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
<img width="1132" alt="截屏2024-08-19 17 04 18" src="https://github.com/user-attachments/assets/12f04f08-240d-4515-836d-041a3927d652">
每次手动调用init都会触发存在bus中的renderLine(defaultValue)，导致dot位置被重置到defaultValue的位置。

通过在init中加入了一个flag检查来解决这个问题，检查是否已经初始化过，如果已经初始化就直接return。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(slider): fix incorrect dot pos caused by repeated manual init

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供