### PR TITLE
fix(collapse-panel): expandIcon does not take effect

### DIFF
--- a/src/collapse-panel/collapse-panel.ts
+++ b/src/collapse-panel/collapse-panel.ts
@@ -23,7 +23,7 @@ export default class CollapsePanel extends SuperComponent {
         const { value, expandIcon, disabled } = target.properties;
 
         this.setData({
-          ultimateExpandIcon: expandIcon || this.properties.expandIcon,
+          ultimateExpandIcon: this.properties.expandIcon == null ? expandIcon : this.properties.expandIcon,
           ultimateDisabled: this.properties.disabled == null ? disabled : this.properties.disabled,
         });
 

--- a/src/collapse-panel/collapse-panel.ts
+++ b/src/collapse-panel/collapse-panel.ts
@@ -43,6 +43,12 @@ export default class CollapsePanel extends SuperComponent {
     ultimateDisabled: false,
   };
 
+  observers = {
+    disabled(v) {
+      this.setData({ ultimateDisabled: !!v });
+    },
+  };
+
   methods = {
     updateExpanded(activeValues = []) {
       if (!this.$parent || this.data.ultimateDisabled) {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

![image](https://github.com/user-attachments/assets/9fc40001-14fe-4f69-b479-34a3483430b5)

父级 `collapse` 默认值为`true` ，所以只在 `collapse-panel` 设置 `false` 无效

### 📝 更新日志


- fix(collapse): 修复collapse-panel设置expand-icon不生效及支持动态设置diabled

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
