### PR TITLE
feat: 新增监听initialIndex值的变化，动态去改变currentSwiperIndex

### DIFF
--- a/src/image-viewer/image-viewer.ts
+++ b/src/image-viewer/image-viewer.ts
@@ -34,6 +34,9 @@ export default class ImageViewer extends SuperComponent {
       key: 'visible',
       event: 'close',
     },
+    {
+      key:'initialIndex'
+    }
   ];
 
   ready() {
@@ -42,6 +45,11 @@ export default class ImageViewer extends SuperComponent {
   }
 
   observers = {
+    initialIndex(value) {
+      this.setData({
+        currentSwiperIndex: value,
+      })
+    },
     visible(value) {
       this.setData({
         currentSwiperIndex: value ? this.properties.initialIndex : 0,
@@ -59,6 +67,8 @@ export default class ImageViewer extends SuperComponent {
         _deleteBtn: calcIcon(v, 'delete'),
       });
     },
+
+
   };
 
   methods = {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-miniprogram/issues/3102


### 💡 需求背景和解决方案

1. ImageViewer组件预览时候，删除当前预览的图片，如果传递了 initial-index，删除多个图片时候，会出现 initial-index比图片列表的长度大的bug。
2. 监听 initialIndex，动态去设置currentSwiperIndex。

### 📝 更新日志

- fix(ImageViewer): 支持动态设置 initial-index 的值

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
