### PR TITLE
fix(t-toast demo): 错别字“弹窗可‘现实’遮罩”

### DIFF
--- a/src/toast/_example/skyline/toast.wxml
+++ b/src/toast/_example/skyline/toast.wxml
@@ -10,7 +10,7 @@
       <t-demo title="02 组件状态" desc="内置主题">
         <theme />
       </t-demo>
-      <t-demo title="03 显示遮罩" desc="弹窗可现实遮罩，禁止滑动和点击">
+      <t-demo title="03 显示遮罩" desc="弹窗可显示遮罩，禁止滑动和点击">
         <cover />
       </t-demo>
       <t-demo title="04 手动关闭" desc="手动关闭轻提示">

--- a/src/toast/_example/toast.wxml
+++ b/src/toast/_example/toast.wxml
@@ -8,7 +8,7 @@
   <t-demo title="02 组件状态" desc="内置主题">
     <theme class="box" />
   </t-demo>
-  <t-demo title="03 显示遮罩" desc="弹窗可现实遮罩，禁止滑动和点击">
+  <t-demo title="03 显示遮罩" desc="弹窗可显示遮罩，禁止滑动和点击">
     <cover class="box" />
   </t-demo>
   <t-demo title="04 手动关闭" desc="手动关闭轻提示">


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 演示代码改进

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Demo 中 t-toast 页存在错别字：弹窗可“现实”遮罩，应为“弹窗可显示遮罩”。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
