### PR TITLE
fix(Tabs): enable hidden on the beginning

### DIFF
--- a/src/common/wechat.ts
+++ b/src/common/wechat.ts
@@ -1,6 +1,7 @@
 export const getObserver = (context, selector: string) => {
   return new Promise((resolve, reject) => {
-    wx.createIntersectionObserver(context)
+    context
+      .createIntersectionObserver(context)
       .relativeToViewport()
       .observe(selector, (res) => {
         resolve(res);

--- a/src/tab-panel/props.ts
+++ b/src/tab-panel/props.ts
@@ -10,11 +10,6 @@ const props: TdTabPanelProps = {
   badgeProps: {
     type: Object,
   },
-  /** 【实现有误，暂不支持】选项卡内容隐藏时是否销毁 */
-  destroyOnHide: {
-    type: Boolean,
-    value: true,
-  },
   /** 是否禁用当前选项卡 */
   disabled: {
     type: Boolean,

--- a/src/tab-panel/type.ts
+++ b/src/tab-panel/type.ts
@@ -15,14 +15,6 @@ export interface TdTabPanelProps {
     value?: object;
   };
   /**
-   * 【实现有误，暂不支持】选项卡内容隐藏时是否销毁
-   * @default true
-   */
-  destroyOnHide?: {
-    type: BooleanConstructor;
-    value?: boolean;
-  };
-  /**
    * 是否禁用当前选项卡
    * @default false
    */

--- a/src/tabs/README.en-US.md
+++ b/src/tabs/README.en-US.md
@@ -45,7 +45,6 @@ name | type | default | description | required
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
 badge-props | Object | - | \- | N
-destroy-on-hide | Boolean | true | \- | N
 disabled | Boolean | false | \- | N
 icon | String / Object | - | \- | N
 label | String | - | \- | N

--- a/src/tabs/README.md
+++ b/src/tabs/README.md
@@ -158,7 +158,6 @@ t-class-track | 滚动条样式类
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
 badge-props | Object | - | 透传至 Badge 组件 | N
-destroy-on-hide | Boolean | true | 【实现有误，暂不支持】选项卡内容隐藏时是否销毁 | N
 disabled | Boolean | false | 是否禁用当前选项卡 | N
 icon | String / Object | - | `1.0.0-rc.1`。图标，传对象则透传至 Icon | N
 label | String | - | 选项卡名称 | N

--- a/src/tabs/tabs.ts
+++ b/src/tabs/tabs.ts
@@ -4,6 +4,7 @@ import config from '../common/config';
 import touch from '../mixins/touch';
 import { getRect, uniqueFactory } from '../common/utils';
 import { TdTabsProps } from './type';
+import { getObserver } from '../common/wechat';
 
 const { prefix } = config;
 const name = `${prefix}-tabs`;
@@ -215,6 +216,9 @@ export default class Tabs extends SuperComponent {
           this.setData({
             offset: Math.min(Math.max(offset, 0), maxOffset),
           });
+        } else if (!this._hasObserved) {
+          this._hasObserved = true;
+          getObserver(this, `.${name}`).then(() => this.setTrack());
         }
 
         if (this.data.theme === 'line') {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
相关api pr：https://github.com/TDesignOteam/tdesign-api/pull/412

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在一开始使用 hidden 隐藏，而 attached 会继续触发，导致无法正确获取布局 width ，最终 tracker 无法正确显示。



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 使用 `hidden` 隐藏后显示仍能够正常显示指示器；移除文档中未实现的 `destroyOnHide` 属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
