### PR TITLE
Docs/progress 修复首次进入时与设置的stroke-width的延迟显示和兼容性问题

### DIFF
--- a/src/image/README.en-US.md
+++ b/src/image/README.en-US.md
@@ -32,6 +32,8 @@ className | Description
 -- | --
 t-class | \-
 t-class-load | \-
+t-class-image | \-
+t-class-error | \-
 
 ### CSS Variables
 

--- a/src/image/README.md
+++ b/src/image/README.md
@@ -77,6 +77,8 @@ load | - | 图片加载完成时触发
 -- | --
 t-class | 根节点样式类
 t-class-load | 加载样式类
+t-class-image | 图片样式类
+t-class-error | 加载失败样式类
 
 ### CSS Variables
 

--- a/src/image/image.less
+++ b/src/image/image.less
@@ -5,13 +5,14 @@
 @image-loading-color: var(--td-image-loading-color, @text-color-placeholder);
 @image-round-radius: var(--td-image-round-radius, @radius-default);
 
-:host {
-  position: relative;
-}
-
 .@{prefix}-image {
-  color: @image-color;
-  vertical-align: top;
+  position: relative;
+  display: inline-block;
+
+  &__img {
+    color: @image-color;
+    vertical-align: top;
+  }
 
   &__mask {
     display: flex;
@@ -34,6 +35,7 @@
   &--lazy {
     position: absolute;
     top: 0;
+    left: 0;
     z-index: -1;
   }
 

--- a/src/image/image.ts
+++ b/src/image/image.ts
@@ -7,7 +7,7 @@ const { prefix } = config;
 const name = `${prefix}-image`;
 @wxComponent()
 export default class Image extends SuperComponent {
-  externalClasses = [`${prefix}-class`, `${prefix}-class-load`];
+  externalClasses = [`${prefix}-class`, `${prefix}-class-load`, `${prefix}-class-image`, `${prefix}-class-error`];
 
   options = {
     multipleSlots: true,

--- a/src/image/image.wxml
+++ b/src/image/image.wxml
@@ -1,52 +1,56 @@
 <wxs src="../common/utils.wxs" module="_" />
 
-<!-- 加载中占位 -->
-<view
-  wx:if="{{isLoading}}"
-  style="{{_._style([innerStyle, style, customStyle])}}"
-  class="class {{prefix}}-class {{classPrefix}} {{classPrefix}}__mask {{classPrefix}}--loading {{classPrefix}}--shape-{{shape}}"
-  aria-hidden="{{ariaHidden}}"
->
-  <t-loading
-    wx:if="{{loading === 'default'}}"
-    theme="dots"
-    size="44rpx"
-    loading
-    inherit-color
-    t-class="t-class-load"
-    t-class-text="{{classPrefix}}--loading-text"
-  ></t-loading>
-  <view wx:elif="{{loading !== '' && loading !== 'slot'}}" class="{{classPrefix}}__common {{prefix}}-class-load">
-    {{loading}}
+<view class="class {{prefix}}-class {{classPrefix}}">
+  <!-- 加载中占位 -->
+  <view
+    wx:if="{{isLoading}}"
+    style="{{_._style([innerStyle, style, customStyle])}}"
+    class="{{classPrefix}}__img {{classPrefix}}__mask {{classPrefix}}--loading {{classPrefix}}--shape-{{shape}}"
+    aria-hidden="{{ariaHidden}}"
+  >
+    <t-loading
+      wx:if="{{loading === 'default'}}"
+      theme="dots"
+      size="44rpx"
+      loading
+      inherit-color
+      t-class="t-class-load"
+      t-class-text="{{classPrefix}}--loading-text"
+    ></t-loading>
+    <view wx:elif="{{loading !== '' && loading !== 'slot'}}" class="{{classPrefix}}__common {{prefix}}-class-load">
+      {{loading}}
+    </view>
+    <slot wx:else name="loading" />
   </view>
-  <slot wx:else name="loading" />
-</view>
-<!-- 加载失败占位 -->
-<view
-  wx:elif="{{isFailed}}"
-  style="{{_._style([innerStyle, style, customStyle])}}"
-  class="class {{prefix}}-class {{classPrefix}} {{classPrefix}}__mask {{classPrefix}}--failed {{classPrefix}}--shape-{{shape}}"
-  aria-hidden="{{ariaHidden}}"
->
-  <view wx:if="{{error === 'default'}}" style="font-size: 44rpx" class="{{prefix}}-class-load">
-    <t-icon name="close" aria-role="img" aria-label="加载失败" />
+  <!-- 加载失败占位 -->
+  <view
+    wx:elif="{{isFailed}}"
+    style="{{_._style([innerStyle, style, customStyle])}}"
+    class="{{classPrefix}}__img {{prefix}}-class-error {{classPrefix}}__mask {{classPrefix}}--failed {{classPrefix}}--shape-{{shape}}"
+    aria-hidden="{{ariaHidden}}"
+  >
+    <view wx:if="{{error === 'default'}}" style="font-size: 44rpx" class="{{prefix}}-class-load">
+      <t-icon name="close" aria-role="img" aria-label="加载失败" />
+    </view>
+    <view wx:elif="{{error && error !== 'slot'}}" class="{{classPrefix}}__common {{prefix}}-class-load">
+      {{error}}
+    </view>
+    <slot wx:else name="error" />
   </view>
-  <view wx:elif="{{error && error !== 'slot'}}" class="{{classPrefix}}__common {{prefix}}-class-load"> {{error}} </view>
-  <slot wx:else name="error" />
+  <!-- 图片 -->
+  <image
+    id="{{tId||'image'}}"
+    wx:if="{{ !isFailed }}"
+    class="{{classPrefix}}__img {{classPrefix}}--shape-{{shape}} {{isLoading ? classPrefix + '--lazy' : ''}}"
+    src="{{src}}"
+    style="{{_._style([innerStyle, style, customStyle])}}"
+    mode="{{mode}}"
+    webp="{{webp}}"
+    lazy-load="{{lazy}}"
+    bind:load="onLoaded"
+    bind:error="onLoadError"
+    show-menu-by-longpress="{{showMenuByLongpress}}"
+    aria-hidden="{{ariaHidden || isLoading || isFailed}}"
+    aria-label="{{ariaLabel}}"
+  />
 </view>
-<!-- 图片 -->
-<image
-  id="{{tId||'image'}}"
-  wx:if="{{ !isFailed }}"
-  class="class {{prefix}}-class {{classPrefix}} {{classPrefix}}--shape-{{shape}} {{isLoading ? classPrefix + '--lazy' : ''}}"
-  src="{{src}}"
-  style="{{_._style([innerStyle, style, customStyle])}}"
-  mode="{{mode}}"
-  webp="{{webp}}"
-  lazy-load="{{lazy}}"
-  bind:load="onLoaded"
-  bind:error="onLoadError"
-  show-menu-by-longpress="{{showMenuByLongpress}}"
-  aria-hidden="{{ariaHidden || isLoading || isFailed}}"
-  aria-label="{{ariaLabel}}"
-/>

--- a/src/progress/progress.ts
+++ b/src/progress/progress.ts
@@ -25,6 +25,7 @@ export default class Progress extends SuperComponent {
     computedStatus: '',
     computedProgress: 0,
     isIOS: false,
+    strokeCircleWidth: '',
   };
 
   attached() {
@@ -64,6 +65,7 @@ export default class Progress extends SuperComponent {
       }
       this.setData({
         heightBar: unitConvert(strokeWidth),
+        strokeCircleWidth: Number.isNaN(strokeWidth) ? '' : `${strokeWidth}px`,
       });
     },
 

--- a/src/progress/progress.ts
+++ b/src/progress/progress.ts
@@ -25,7 +25,6 @@ export default class Progress extends SuperComponent {
     computedStatus: '',
     computedProgress: 0,
     isIOS: false,
-    strokeCircleWidth: '',
   };
 
   attached() {
@@ -65,15 +64,9 @@ export default class Progress extends SuperComponent {
       }
       this.setData({
         heightBar: unitConvert(strokeWidth),
-        strokeCircleWidth: Number.isNaN(strokeWidth) ? '' : `${strokeWidth}px`,
       });
     },
 
-    theme(theme) {
-      if (theme === 'circle') {
-        this.getInnerDiameter();
-      }
-    },
 
     trackColor(trackColor) {
       this.setData({
@@ -82,17 +75,4 @@ export default class Progress extends SuperComponent {
     },
   };
 
-  methods = {
-    getInnerDiameter() {
-      const { strokeWidth } = this.properties;
-      const wrapID = `.${name}__canvas--circle`;
-      if (strokeWidth) {
-        getRect(this, wrapID).then((wrapRect) => {
-          this.setData({
-            innerDiameter: wrapRect.width - unitConvert(strokeWidth) * 2,
-          });
-        });
-      }
-    },
-  };
 }

--- a/src/progress/progress.wxml
+++ b/src/progress/progress.wxml
@@ -80,7 +80,7 @@
     >
       <view
         class="{{classPrefix}}__canvas--inner {{prefix}}-class-bar"
-        style="{{innerDiameter? 'width:'+ innerDiameter*2 + 'rpx;' + 'height:'+ innerDiameter*2 + 'rpx;': ''}}"
+        style="{{strokeCircleWidth? '--td-progress-stroke-circle-width:'+ strokeCircleWidth : ''}}"
       >
         <view wx:if="{{label}}" class="{{classPrefix}}__info {{prefix}}-class-label" aria-hidden="{{ true }}">
           <template

--- a/src/progress/progress.wxml
+++ b/src/progress/progress.wxml
@@ -80,7 +80,7 @@
     >
       <view
         class="{{classPrefix}}__canvas--inner {{prefix}}-class-bar"
-        style="{{strokeCircleWidth? '--td-progress-stroke-circle-width:'+ strokeCircleWidth : ''}}"
+        style="{{heightBar? '--td-progress-stroke-circle-width:' + heightBar + 'px' : ''}}"
       >
         <view wx:if="{{label}}" class="{{classPrefix}}__info {{prefix}}-class-label" aria-hidden="{{ true }}">
           <template


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景： 在使用progress组件时 当小程序首次进来的时候 会出现外部设置了stroke-width 但是在最开始的时候还是能看到组件本身的默认值 要等一小会才会更新视图 虽然说理论上都要先做单位转换， 直接*2  除了375的屏幕，其他屏幕下会有出入  #但是我觉得起码这样可以先解决大问题😄😄
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Progress): 修复环形进度条首次加载时，`strokeWidth` 线宽延迟显示的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
