### PR TITLE
fix(ImageViewer): 修复滚动穿透问题

### DIFF
--- a/src/image-viewer/image-viewer.wxml
+++ b/src/image-viewer/image-viewer.wxml
@@ -9,6 +9,7 @@
   aria-modal="{{true}}"
   aria-role="dialog"
   aria-label="图片查看器"
+  catchtouchmove="true"
 >
   <view
     class="{{classPrefix}}__mask"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- 日常 bug 修复

### 💡 需求背景和解决方案

1、背景：当前页面可以滑动时候，如果使用了image-viewer组件来预览图片，在image-viewer组件层滑动，会出现滚动穿透
2、方案：禁止滚动穿透

### 📝 更新日志


- fix(ImageViewer): 修复滚动穿透问题

- 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
