### PR TITLE
fix(Tabs): fixed the problem of not being able to scroll under skyline

### DIFF
--- a/src/tabs/tabs.less
+++ b/src/tabs/tabs.less
@@ -172,10 +172,13 @@
   &__nav {
     position: relative;
     user-select: none;
-    width: 100%;
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
+  }
+
+  &__nav&__nav--evenly {
+    width: 100%;
   }
 
   &__track {

--- a/src/tabs/tabs.wxml
+++ b/src/tabs/tabs.wxml
@@ -26,7 +26,7 @@
         type="list"
         bind:scroll="onScroll"
       >
-        <view class="{{_.cls(classPrefix + '__nav', [placement])}}" aria-role="tablist">
+        <view class="{{_.cls(classPrefix + '__nav', [placement, ['evenly', spaceEvenly]])}}" aria-role="tablist">
           <view
             wx:for="{{tabs}}"
             wx:key="index"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3169 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
表现：scroll-view组件，相同代码在 webview 和 skyline 下表现不一致
可能原因：skyline 实现与 webview 不一致
最小复现片段：https://developers.weixin.qq.com/s/CbNx7OmP7yUE

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复在 skyline 中无法滚动的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
