### PR TITLE
fix(Navbar): Fixed getRect caused navbar position to be inaccurate

### DIFF
--- a/src/navbar/__test__/__snapshots__/index.test.js.snap
+++ b/src/navbar/__test__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`navbar :base 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--visible-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -40,7 +40,7 @@ exports[`navbar :base 2`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -75,7 +75,7 @@ exports[`navbar :base 3`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -110,7 +110,7 @@ exports[`navbar :fixed 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--visible-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -145,7 +145,7 @@ exports[`navbar :menu button 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed  class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-left: 375px; --td-navbar-center-width: -375px; --td-navbar-right: 375px; --td-navbar-capsule-height: 10px; --td-navbar-capsule-width: 40px; --td-navbar-height: -10px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: -375px; --td-navbar-right: 375px; --td-navbar-capsule-height: 10px; --td-navbar-capsule-width: 40px; --td-navbar-height: -10px; --td-navbar-center-left: 375px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"

--- a/src/navbar/__test__/__snapshots__/index.test.js.snap
+++ b/src/navbar/__test__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`navbar :base 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--visible-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-left-max-width: 281px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -40,7 +40,7 @@ exports[`navbar :base 2`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-left-max-width: 281px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -75,7 +75,7 @@ exports[`navbar :base 3`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--hide class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-left-max-width: 281px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -110,7 +110,7 @@ exports[`navbar :fixed 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed t-navbar--visible-animation class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: 187px; --td-navbar-right: 94px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 94px; --td-navbar-left-max-width: 281px; --td-navbar-capsule-height: 32px; --td-navbar-capsule-width: 87px; --td-navbar-height: 40px; --td-navbar-center-left: 94px; --td-navbar-center-width: 187px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"
@@ -145,7 +145,7 @@ exports[`navbar :menu button 1`] = `
   <t-navbar>
     <wx-view
       class="t-navbar t-navbar--fixed  class t-class"
-      style="--td-navbar-padding-top: 20px; --td-navbar-center-width: -375px; --td-navbar-right: 375px; --td-navbar-capsule-height: 10px; --td-navbar-capsule-width: 40px; --td-navbar-height: -10px; --td-navbar-center-left: 375px;"
+      style="--td-navbar-padding-top: 20px; --td-navbar-right: 375px; --td-navbar-left-max-width: 0px; --td-navbar-capsule-height: 10px; --td-navbar-capsule-width: 40px; --td-navbar-height: -10px; --td-navbar-center-left: 375px; --td-navbar-center-width: 0px;"
     >
       <wx-view
         class="t-navbar__placeholder t-class-placeholder"

--- a/src/navbar/navbar.less
+++ b/src/navbar/navbar.less
@@ -21,7 +21,6 @@
 @navbar-capsule-border-radius: var(--td-navbar-capsule-border-radius, 16px);
 @navbar-capsule-width: var(--td-navbar-capsule-width, 88px);
 @navbar-capsule-height: var(--td-navbar-capsule-height, 32px);
-// var(--capsule-height)
 
 .@{prefix}-navbar {
   &--fixed {
@@ -78,7 +77,8 @@
   &__left {
     position: relative;
     box-sizing: border-box;
-    // width: @navbar-right;
+    max-width: var(--td-navbar-left-max-width);
+    overflow: hidden;
     display: flex;
     align-items: center;
     margin-left: @spacer-1;

--- a/src/navbar/navbar.ts
+++ b/src/navbar/navbar.ts
@@ -75,8 +75,7 @@ export default class Navbar extends SuperComponent {
     }
     if (!rect || !systemInfo) return;
 
-    const { right } = await getRect(this, `.${name}__left`);
-
+    const right = 36;
     const boxStyleList = [];
     boxStyleList.push(`--td-navbar-padding-top: ${systemInfo.statusBarHeight}px`);
     if (rect && systemInfo?.windowWidth) {
@@ -84,6 +83,18 @@ export default class Navbar extends SuperComponent {
       boxStyleList.push(`--td-navbar-center-left: ${maxSpacing}px`); // 标题左侧距离
       boxStyleList.push(`--td-navbar-center-width: ${rect.left - maxSpacing}px`); // 标题宽度
       boxStyleList.push(`--td-navbar-right: ${systemInfo.windowWidth - rect.left}px`); // 导航栏右侧小程序胶囊按钮宽度
+
+      // getRect方法耗时较长，真机约600ms，会导致navbar位置长时间不准确，所以先设置默认值，再异步获取
+      getRect(this, `.${name}__left`).then((rect2) => {
+        if (rect2.right !== right) {
+          const boxStyleList2 = boxStyleList.filter((item) => !item.startsWith('--td-navbar-center-left'));
+          const maxSpacing2 = Math.max(rect2.right, systemInfo.windowWidth - rect.left);
+          boxStyleList2.push(`--td-navbar-center-left: ${maxSpacing2}px`);
+          this.setData({
+            boxStyle: `${boxStyleList2.join('; ')}`,
+          });
+        }
+      });
     }
     boxStyleList.push(`--td-navbar-capsule-height: ${rect.height}px`); // 胶囊高度
     boxStyleList.push(`--td-navbar-capsule-width: ${rect.width}px`); // 胶囊宽度

--- a/src/navbar/navbar.ts
+++ b/src/navbar/navbar.ts
@@ -47,6 +47,7 @@ export default class Navbar extends SuperComponent {
         }, 300);
       }
     },
+
     'title,titleMaxLength'(this: any) {
       const { title } = this.properties;
       const titleMaxLength = this.properties.titleMaxLength || Number.MAX_SAFE_INTEGER;
@@ -65,61 +66,94 @@ export default class Navbar extends SuperComponent {
     showTitle: '',
     hideLeft: false, // 隐藏左侧内容
     hideCenter: false, // 隐藏中部内容
+    _menuRect: null, // 胶囊按钮节点信息
+    _leftRect: null, // 左侧节点信息
+    _boxStyle: {}, // 记录样式
   };
 
-  async attached() {
-    // 场景值为1177（视频号直播间）和1175 （视频号profile页）时，小程序禁用了 wx.getMenuButtonBoundingClientRect
-    let rect = null;
-    if (wx.getMenuButtonBoundingClientRect) {
-      rect = wx.getMenuButtonBoundingClientRect();
-    }
-    if (!rect || !systemInfo) return;
-
-    const right = 36;
-    const boxStyleList = [];
-    boxStyleList.push(`--td-navbar-padding-top: ${systemInfo.statusBarHeight}px`);
-    if (rect && systemInfo?.windowWidth) {
-      const maxSpacing = Math.max(right, systemInfo.windowWidth - rect.left);
-      boxStyleList.push(`--td-navbar-center-left: ${maxSpacing}px`); // 标题左侧距离
-      boxStyleList.push(`--td-navbar-center-width: ${rect.left - maxSpacing}px`); // 标题宽度
-      boxStyleList.push(`--td-navbar-right: ${systemInfo.windowWidth - rect.left}px`); // 导航栏右侧小程序胶囊按钮宽度
-
-      // getRect方法耗时较长，真机约600ms，会导致navbar位置长时间不准确，所以先设置默认值，再异步获取
-      getRect(this, `.${name}__left`).then((rect2) => {
-        if (rect2.right !== right) {
-          const boxStyleList2 = boxStyleList.filter((item) => !item.startsWith('--td-navbar-center-left'));
-          const maxSpacing2 = Math.max(rect2.right, systemInfo.windowWidth - rect.left);
-          boxStyleList2.push(`--td-navbar-center-left: ${maxSpacing2}px`);
-          this.setData({
-            boxStyle: `${boxStyleList2.join('; ')}`,
-          });
-        }
-      });
-    }
-    boxStyleList.push(`--td-navbar-capsule-height: ${rect.height}px`); // 胶囊高度
-    boxStyleList.push(`--td-navbar-capsule-width: ${rect.width}px`); // 胶囊宽度
-    boxStyleList.push(`--td-navbar-height: ${(rect.top - systemInfo.statusBarHeight) * 2 + rect.height}px`);
-    this.setData({
-      boxStyle: `${boxStyleList.join('; ')}`,
-    });
-    // @ts-ignore
-    if (wx.onMenuButtonBoundingClientRectWeightChange) {
-      // fixme: 规避单元测试无法识别新api，更新后可删除
-      // @ts-ignore
-      wx.onMenuButtonBoundingClientRectWeightChange((res: object) => this.queryElements(res)); // 监听胶囊条长度变化，隐藏遮挡的内容
-    }
+  attached() {
+    this.initStyle();
+    this.getLeftRect();
+    this.onMenuButtonBoundingClientRectWeightChange();
   }
 
   detached() {
-    // @ts-ignore
-    if (wx.offMenuButtonBoundingClientRectWeightChange) {
-      // fixme: 规避单元测试无法识别新api，更新后可删除
-      // @ts-ignore
-      wx.offMenuButtonBoundingClientRectWeightChange((res: object) => this.queryElements(res));
-    }
+    this.offMenuButtonBoundingClientRectWeightChange();
   }
 
   methods = {
+    initStyle() {
+      this.getMenuRect();
+
+      const { _menuRect, _leftRect } = this.data;
+
+      if (!_menuRect || !_leftRect || !systemInfo) return;
+
+      const _boxStyleList = {};
+      _boxStyleList['--td-navbar-padding-top'] = `${systemInfo.statusBarHeight}px`;
+      _boxStyleList['--td-navbar-right'] = `${systemInfo.windowWidth - _menuRect.left}px`; // 导航栏右侧小程序胶囊按钮宽度
+      _boxStyleList['--td-navbar-left-max-width'] = `${_menuRect.left}px`; // 左侧内容最大宽度
+      _boxStyleList['--td-navbar-capsule-height'] = `${_menuRect.height}px`; // 胶囊高度
+      _boxStyleList['--td-navbar-capsule-width'] = `${_menuRect.width}px`; // 胶囊宽度
+      _boxStyleList['--td-navbar-height'] = `${(_menuRect.top - systemInfo.statusBarHeight) * 2 + _menuRect.height}px`;
+
+      this.calcCenterStyle(_leftRect, _menuRect, _boxStyleList);
+    },
+
+    calcCenterStyle(
+      leftRect: WechatMiniprogram.BoundingClientRectResult,
+      menuRect: WechatMiniprogram.BoundingClientRectResult,
+      defaultStyle: object,
+    ) {
+      const maxSpacing = Math.max(leftRect.right, systemInfo.windowWidth - menuRect.left);
+      const _boxStyleObj = {};
+
+      _boxStyleObj['--td-navbar-center-left'] = `${maxSpacing}px`; // 标题左侧距离
+      _boxStyleObj['--td-navbar-center-width'] = `${Math.max(menuRect.left - maxSpacing, 0)}px`; // 标题宽度
+
+      const boxStyle = Object.entries({ ...defaultStyle, ..._boxStyleObj })
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('; ');
+
+      this.setData({
+        boxStyle,
+        _boxStyle: { ...defaultStyle, ..._boxStyleObj },
+      });
+    },
+
+    getLeftRect() {
+      getRect(this, `.${name}__left`).then((res) => {
+        if (res.right > this.data._leftRect.right) {
+          this.calcCenterStyle(res, this.data._menuRect, this.data._boxStyle);
+        }
+      });
+    },
+
+    getMenuRect() {
+      // 场景值为1177（视频号直播间）和1175 （视频号profile页）时，小程序禁用了 wx.getMenuButtonBoundingClientRect
+      if (wx.getMenuButtonBoundingClientRect) {
+        const rect = wx.getMenuButtonBoundingClientRect();
+        this.setData({
+          _menuRect: rect,
+          _leftRect: {
+            right: systemInfo.windowWidth - rect.left,
+          },
+        });
+      }
+    },
+
+    onMenuButtonBoundingClientRectWeightChange() {
+      if (wx.onMenuButtonBoundingClientRectWeightChange) {
+        wx.onMenuButtonBoundingClientRectWeightChange((res: object) => this.queryElements(res)); // 监听胶囊条长度变化，隐藏遮挡的内容
+      }
+    },
+
+    offMenuButtonBoundingClientRectWeightChange() {
+      if (wx.offMenuButtonBoundingClientRectWeightChange) {
+        wx.offMenuButtonBoundingClientRectWeightChange((res: object) => this.queryElements(res));
+      }
+    },
+
     /**
      * 比较胶囊条和navbar内容，决定是否隐藏
      * @param capsuleRect API返回值，胶囊条的位置信息
@@ -129,12 +163,13 @@ export default class Navbar extends SuperComponent {
         getRect(this, `.${this.data.classPrefix}__left`),
         getRect(this, `.${this.data.classPrefix}__center`),
       ]).then(([leftRect, centerRect]) => {
-        if (leftRect.right > capsuleRect.left) {
+        // 部分安卓机型中（目前仅在Magic6/7中复现），仍存在精度问题，暂使用 Math.round() 取整规避
+        if (Math.round(leftRect.right) > capsuleRect.left) {
           this.setData({
             hideLeft: true,
             hideCenter: true,
           });
-        } else if (centerRect.right > capsuleRect.left) {
+        } else if (Math.round(centerRect.right) > capsuleRect.left) {
           this.setData({
             hideLeft: false,
             hideCenter: true,

--- a/src/navbar/navbar.ts
+++ b/src/navbar/navbar.ts
@@ -89,15 +89,16 @@ export default class Navbar extends SuperComponent {
 
       if (!_menuRect || !_leftRect || !systemInfo) return;
 
-      const _boxStyleList = {};
-      _boxStyleList['--td-navbar-padding-top'] = `${systemInfo.statusBarHeight}px`;
-      _boxStyleList['--td-navbar-right'] = `${systemInfo.windowWidth - _menuRect.left}px`; // 导航栏右侧小程序胶囊按钮宽度
-      _boxStyleList['--td-navbar-left-max-width'] = `${_menuRect.left}px`; // 左侧内容最大宽度
-      _boxStyleList['--td-navbar-capsule-height'] = `${_menuRect.height}px`; // 胶囊高度
-      _boxStyleList['--td-navbar-capsule-width'] = `${_menuRect.width}px`; // 胶囊宽度
-      _boxStyleList['--td-navbar-height'] = `${(_menuRect.top - systemInfo.statusBarHeight) * 2 + _menuRect.height}px`;
+      const _boxStyle = {
+        '--td-navbar-padding-top': `${systemInfo.statusBarHeight}px`,
+        '--td-navbar-right': `${systemInfo.windowWidth - _menuRect.left}px`, // 导航栏右侧小程序胶囊按钮宽度
+        '--td-navbar-left-max-width': `${_menuRect.left}px`, // 左侧内容最大宽度
+        '--td-navbar-capsule-height': `${_menuRect.height}px`, // 胶囊高度
+        '--td-navbar-capsule-width': `${_menuRect.width}px`, // 胶囊宽度
+        '--td-navbar-height': `${(_menuRect.top - systemInfo.statusBarHeight) * 2 + _menuRect.height}px`,
+      };
 
-      this.calcCenterStyle(_leftRect, _menuRect, _boxStyleList);
+      this.calcCenterStyle(_leftRect, _menuRect, _boxStyle);
     },
 
     calcCenterStyle(
@@ -106,18 +107,19 @@ export default class Navbar extends SuperComponent {
       defaultStyle: object,
     ) {
       const maxSpacing = Math.max(leftRect.right, systemInfo.windowWidth - menuRect.left);
-      const _boxStyleObj = {};
+      const _boxStyle = {
+        ...defaultStyle,
+        '--td-navbar-center-left': `${maxSpacing}px`, // 标题左侧距离
+        '--td-navbar-center-width': `${Math.max(menuRect.left - maxSpacing, 0)}px`, // 标题宽度
+      };
 
-      _boxStyleObj['--td-navbar-center-left'] = `${maxSpacing}px`; // 标题左侧距离
-      _boxStyleObj['--td-navbar-center-width'] = `${Math.max(menuRect.left - maxSpacing, 0)}px`; // 标题宽度
-
-      const boxStyle = Object.entries({ ...defaultStyle, ..._boxStyleObj })
+      const boxStyle = Object.entries(_boxStyle)
         .map(([k, v]) => `${k}: ${v}`)
         .join('; ');
 
       this.setData({
         boxStyle,
-        _boxStyle: { ...defaultStyle, ..._boxStyleObj },
+        _boxStyle,
       });
     },
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3302
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题点：
1. getRect方法耗时较长，真机约600ms，会导致navbar位置长时间不准确，所以先设置默认值，再异步获取
2. 部分安卓机型中（已在Magic6/7中复现，可能荣耀Magic系列均能复现🤔），仍存在精度问题，导致翻译功能完成后标题区域仍然隐藏，暂使用 Math.round() 取整规避


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Navbar): 修复 `getRect` 耗时过长导致 `navbar` 位置不准确问题，并兼容部分机型因精度问题导致的翻译功能完成后标题仍然隐藏的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
