### PR TITLE
feat(cascader): 新增 checkStrictly 属性，父子节点选中状态不再关联，可各自选中或取消

### DIFF
--- a/src/cascader/README.en-US.md
+++ b/src/cascader/README.en-US.md
@@ -8,6 +8,7 @@ name | type | default | description | required
 -- | -- | -- | -- | --
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
+check-strictly | Boolean | false | \- | N
 close-btn | Boolean / Slot | true | [see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 keys | Object | - | Typescript：`KeysType`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 options | Array | [] | Typescript：`Array<CascaderOption>` | N

--- a/src/cascader/README.md
+++ b/src/cascader/README.md
@@ -60,6 +60,7 @@ isComponent: true
 -- | -- | -- | -- | --
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
+check-strictly | Boolean | false | 父子节点选中状态不再关联，可各自选中或取消 | N
 close-btn | Boolean / Slot | true | 关闭按钮。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 keys | Object | - | 用来定义 value / label 在 `options` 中对应的字段别名。TS 类型：`KeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 options | Array | [] | 可选项数据源。TS 类型：`Array<CascaderOption>` | N

--- a/src/cascader/_example/cascader.json
+++ b/src/cascader/_example/cascader.json
@@ -5,6 +5,7 @@
     "theme-tab": "./theme-tab",
     "keys": "./keys",
     "with-value": "./with-value",
-    "with-title": "./with-title"
+    "with-title": "./with-title",
+    "check-strictly": "./check-strictly"
   }
 }

--- a/src/cascader/_example/cascader.wxml
+++ b/src/cascader/_example/cascader.wxml
@@ -21,4 +21,8 @@
   <t-demo desc="使用次级标题">
     <with-title />
   </t-demo>
+
+  <t-demo desc="选择任意一项">
+    <check-strictly />
+  </t-demo>
 </view>

--- a/src/cascader/_example/check-strictly/index.js
+++ b/src/cascader/_example/check-strictly/index.js
@@ -1,0 +1,85 @@
+const data = {
+  areaList: [
+    {
+      label: '北京市',
+      value: '110000',
+      children: [
+        {
+          value: '110100',
+          label: '北京市',
+          children: [
+            { value: '110101', label: '东城区' },
+            { value: '110102', label: '西城区' },
+            { value: '110105', label: '朝阳区' },
+            { value: '110106', label: '丰台区' },
+            { value: '110107', label: '石景山区' },
+            { value: '110108', label: '海淀区' },
+            { value: '110109', label: '门头沟区' },
+            { value: '110111', label: '房山区' },
+            { value: '110112', label: '通州区' },
+            { value: '110113', label: '顺义区' },
+            { value: '110114', label: '昌平区' },
+            { value: '110115', label: '大兴区' },
+            { value: '110116', label: '怀柔区' },
+            { value: '110117', label: '平谷区' },
+            { value: '110118', label: '密云区' },
+            { value: '110119', label: '延庆区' },
+          ],
+        },
+      ],
+    },
+    {
+      label: '天津市',
+      value: '120000',
+      children: [
+        {
+          value: '120100',
+          label: '天津市',
+          children: [
+            { value: '120101', label: '和平区' },
+            { value: '120102', label: '河东区' },
+            { value: '120103', label: '河西区' },
+            { value: '120104', label: '南开区' },
+            { value: '120105', label: '河北区' },
+            { value: '120106', label: '红桥区' },
+            { value: '120110', label: '东丽区' },
+            { value: '120111', label: '西青区' },
+            { value: '120112', label: '津南区' },
+            { value: '120113', label: '北辰区' },
+            { value: '120114', label: '武清区' },
+            { value: '120115', label: '宝坻区' },
+            { value: '120116', label: '滨海新区' },
+            { value: '120117', label: '宁河区' },
+            { value: '120118', label: '静海区' },
+            { value: '120119', label: '蓟州区' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+Component({
+  data: {
+    options: data.areaList,
+    note: '请选择地址',
+    visible: false,
+    value: '',
+  },
+  methods: {
+    showCascader() {
+      this.setData({ visible: true });
+    },
+    onPick(e) {
+      console.log(e.detail);
+    },
+    onChange(e) {
+      const { selectedOptions, value } = e.detail;
+      console.log(value);
+      this.setData({
+        value,
+        note: selectedOptions.map((item) => item.label).join('/'),
+      });
+    },
+  },
+});

--- a/src/cascader/_example/check-strictly/index.json
+++ b/src/cascader/_example/check-strictly/index.json
@@ -1,0 +1,7 @@
+{
+  "component": true,
+  "usingComponents": {
+    "t-cell": "tdesign-miniprogram/cell/cell",
+    "t-cascader": "tdesign-miniprogram/cascader/cascader"
+  }
+}

--- a/src/cascader/_example/check-strictly/index.wxml
+++ b/src/cascader/_example/check-strictly/index.wxml
@@ -1,0 +1,14 @@
+<t-cell title="地址" note="{{note}}" bind:click="showCascader" arrow />
+
+<t-cascader
+  close-btn="{{false}}"
+  check-strictly="{{true}}"
+  visible="{{visible}}"
+  value="{{value}}"
+  options="{{options}}"
+  title="请选择地址"
+  bind:change="onChange"
+  bind:pick="onPick"
+>
+  <text class="confirm-btn" slot="close-btn">确定</text>
+</t-cascader>

--- a/src/cascader/_example/check-strictly/index.wxss
+++ b/src/cascader/_example/check-strictly/index.wxss
@@ -1,0 +1,3 @@
+.confirm-btn {
+  color: #0052d9;
+}

--- a/src/cascader/props.ts
+++ b/src/cascader/props.ts
@@ -6,6 +6,11 @@
 
 import { TdCascaderProps } from './type';
 const props: TdCascaderProps = {
+  /** 父子节点选中状态不再关联，可各自选中或取消 */
+  checkStrictly: {
+    type: Boolean,
+    value: false,
+  },
   /** 关闭按钮 */
   closeBtn: {
     type: Boolean,

--- a/src/cascader/type.ts
+++ b/src/cascader/type.ts
@@ -8,6 +8,14 @@ import { TreeOptionData, KeysType } from '../common/common';
 
 export interface TdCascaderProps<CascaderOption extends TreeOptionData = TreeOptionData> {
   /**
+   * 父子节点选中状态不再关联，可各自选中或取消
+   * @default false
+   */
+  checkStrictly?: {
+    type: BooleanConstructor;
+    value?: boolean;
+  };
+  /**
    * 关闭按钮
    * @default true
    */


### PR DESCRIPTION
fix #3284

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#3284

api变更: https://github.com/TDesignOteam/tdesign-api/pull/486

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feature(cascader): 新增 checkStrictly 属性，父子节点选中状态不再关联，可各自选中或取消

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
