### PR TITLE
fix(DropdownMenu): fix some CSS variable naming errors

### DIFF
--- a/src/dropdown-menu/README.en-US.md
+++ b/src/dropdown-menu/README.en-US.md
@@ -74,14 +74,14 @@ t-class-footer | \-
 The component provides the following CSS variables, which can be used to customize styles.
 Name | Default Value | Description 
 -- | -- | --
---td-dropdown-menu-active-colorm | @brand-color | - 
---td-dropdown-menu-bg-colorm | @bg-color-container | - 
+--td-dropdown-menu-active-color | @brand-color | - 
+--td-dropdown-menu-bg-color | @bg-color-container | - 
 --td-dropdown-menu-border-width | 1px | - 
---td-dropdown-menu-colorm | @text-color-primary | - 
---td-dropdown-menu-disabled-colorm | @text-color-disabled | - 
---td-dropdown-menu-font-sizem | 28rpx | - 
+--td-dropdown-menu-color | @text-color-primary | - 
+--td-dropdown-menu-disabled-color | @text-color-disabled | - 
+--td-dropdown-menu-font-size | 28rpx | - 
 --td-dropdown-menu-height | 96rpx | - 
---td-dropdown-menu-icon-sizem | 40rpx | - 
+--td-dropdown-menu-icon-size | 40rpx | - 
 --td-dropdown-body-max-height | 560rpx | - 
 --td-dropdown-menu-bg-color | @bg-color-container | - 
 --td-tree-bg-color | @bg-color-container | - 

--- a/src/dropdown-menu/README.md
+++ b/src/dropdown-menu/README.md
@@ -121,14 +121,14 @@ t-class-footer | 底部样式类
 组件提供了下列 CSS 变量，可用于自定义样式。
 名称 | 默认值 | 描述 
 -- | -- | --
---td-dropdown-menu-active-colorm | @brand-color | - 
---td-dropdown-menu-bg-colorm | @bg-color-container | - 
+--td-dropdown-menu-active-color | @brand-color | - 
+--td-dropdown-menu-bg-color | @bg-color-container | - 
 --td-dropdown-menu-border-width | 1px | - 
---td-dropdown-menu-colorm | @text-color-primary | - 
---td-dropdown-menu-disabled-colorm | @text-color-disabled | - 
---td-dropdown-menu-font-sizem | 28rpx | - 
+--td-dropdown-menu-color | @text-color-primary | - 
+--td-dropdown-menu-disabled-color | @text-color-disabled | - 
+--td-dropdown-menu-font-size | 28rpx | - 
 --td-dropdown-menu-height | 96rpx | - 
---td-dropdown-menu-icon-sizem | 40rpx | - 
+--td-dropdown-menu-icon-size | 40rpx | - 
 --td-dropdown-body-max-height | 560rpx | - 
 --td-dropdown-menu-bg-color | @bg-color-container | - 
 --td-tree-bg-color | @bg-color-container | - 

--- a/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
+++ b/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
@@ -16,7 +16,7 @@ exports[`dropdown-menu :base 1`] = `
         ariaExpanded="{{true}}"
         ariaHaspopup="menu"
         ariaRole="button"
-        class="t-dropdown-menu__item t-dropdown-menu__item--active t-class-item"
+        class="t-dropdown-menu__item t-dropdown-menu__item--active t-dropdown-menu__item--0 t-class-item"
         data-index="{{0}}"
         bind:tap="handleToggle"
       >
@@ -49,7 +49,7 @@ exports[`dropdown-menu :base 1`] = `
         ariaExpanded="{{false}}"
         ariaHaspopup="menu"
         ariaRole="button"
-        class="t-dropdown-menu__item t-class-item"
+        class="t-dropdown-menu__item t-dropdown-menu__item--1 t-class-item"
         data-index="{{1}}"
         bind:tap="handleToggle"
       >

--- a/src/dropdown-menu/dropdown-menu.less
+++ b/src/dropdown-menu/dropdown-menu.less
@@ -1,12 +1,12 @@
 @import '../common/style/index.less';
 
 @dropdown-menu-height: var(--td-dropdown-menu-height, 96rpx);
-@dropdown-menu-bg-color: var(--td-dropdown-menu-bg-colorm, @bg-color-container);
-@dropdown-menu-color: var(--td-dropdown-menu-colorm, @text-color-primary);
-@dropdown-menu-active-color: var(--td-dropdown-menu-active-colorm, @brand-color);
-@dropdown-menu-disabled-color: var(--td-dropdown-menu-disabled-colorm, @text-color-disabled);
-@dropdown-menu-font-size: var(--td-dropdown-menu-font-sizem, 28rpx);
-@dropdown-menu-icon-size: var(--td-dropdown-menu-icon-sizem, 40rpx);
+@dropdown-menu-bg-color: var(--td-dropdown-menu-bg-color, @bg-color-container);
+@dropdown-menu-color: var(--td-dropdown-menu-color, @text-color-primary);
+@dropdown-menu-active-color: var(--td-dropdown-menu-active-color, @brand-color);
+@dropdown-menu-disabled-color: var(--td-dropdown-menu-disabled-color, @text-color-disabled);
+@dropdown-menu-font-size: var(--td-dropdown-menu-font-size, 28rpx);
+@dropdown-menu-icon-size: var(--td-dropdown-menu-icon-size, 40rpx);
 @dropdown-menu-border-width: var(--td-dropdown-menu-border-width, 1px);
 
 @dropdownMenu: ~'@{prefix}-dropdown-menu';

--- a/src/dropdown-menu/dropdown-menu.wxml
+++ b/src/dropdown-menu/dropdown-menu.wxml
@@ -12,7 +12,7 @@
     wx:key="index"
     bindtap="handleToggle"
     data-index="{{index}}"
-    class="{{_.cls(classPrefix + '__item', [['active', activeIdx == index], ['disabled', item.disabled]])}} {{prefix}}-class-item"
+    class="{{_.cls(classPrefix + '__item', [['active', activeIdx == index], ['disabled', item.disabled], [index, true]])}} {{prefix}}-class-item"
     aria-disabled="{{item.disabled}}"
     aria-role="button"
     aria-expanded="{{activeIdx === index}}"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3336 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
需求背景：针对 #3336 问题，新增 t-dropdown-menu__item--x 类名，通过在页面上覆盖该 class 类名，达到重写 label 样式，请注意样式隔离问题

<img width="593" alt="企业微信截图_017794a4-a2fc-4075-991b-0e31f58afb06" src="https://github.com/user-attachments/assets/b937ec55-6567-4ead-910a-7f5a1025807d">

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DropdownMenu): 修复部分 `css vars` 命名错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
