### PR TITLE
feat(TreeSelect): support customValue props

### DIFF
--- a/src/tree-select/tree-select.wxml
+++ b/src/tree-select/tree-select.wxml
@@ -62,7 +62,7 @@
     <t-checkbox-group
       wx:else
       class="{{classPrefix}}__checkbox {{prefix}}-class-right-column"
-      value="{{innerValue[level]}}"
+      value="{{innerValue[level] || []}}"
       bind:change="handleRadioChange"
       data-level="{{level}}"
     >


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：来自内部业务需求，用于 search + TreeSelect 场景。 customValue 优先级高于 value，与value的区别在于 value 为空数组场景。 

1. value 为 空数组时，默认取每列索引0为选中项
2. 使用 customValue 时，选中值完全由 customValue 决定，这就意味着 customValue 为空数组时，不会有选中项

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(TreeSelect): 新增 `customValue` 属性，自定义选中值，用于弥补 `value` 为空数组场景

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
