### PR TITLE
chore(Mpx): compatible with Mpx framework

### DIFF
--- a/src/avatar/avatar.wxml
+++ b/src/avatar/avatar.wxml
@@ -44,7 +44,7 @@
       <template
         wx:elif="{{iconName || _.isNoEmptyObj(iconData)}}"
         is="icon"
-        data="{{class: classPrefix + '__icon', tClass: prefix + '-class-icon', name: iconName, ...iconData}}"
+        data="{{tClass: classPrefix + '__icon ' + prefix + '-class-icon', name: iconName, ...iconData}}"
       />
       <view wx:else class="{{classPrefix}}__text {{prefix}}-class-content">
         <slot />

--- a/src/button/button.wxml
+++ b/src/button/button.wxml
@@ -33,7 +33,7 @@
   <template
     wx:if="{{_icon}}"
     is="icon"
-    data="{{class: classPrefix + '__icon', tClass: prefix + '-class-icon', ariaHidden: true, name: iconName, ..._icon}}"
+    data="{{tClass: classPrefix + '__icon ' + prefix + '-class-icon', ariaHidden: true, name: iconName, ..._icon}}"
   />
   <t-loading
     wx:if="{{loading}}"

--- a/src/calendar/template.wxml
+++ b/src/calendar/template.wxml
@@ -73,7 +73,7 @@
     <block wx:elif="{{innerConfirmBtn}}">
       <template
         is="button"
-        data="{{ block: true,  theme: 'primary', class: 't-calendar__confirm-btn', content: realLocalText.confirm, ...innerConfirmBtn }}"
+        data="{{ block: true,  theme: 'primary', rootClass: 't-calendar__confirm-btn', content: realLocalText.confirm, ...innerConfirmBtn }}"
       />
     </block>
   </view>

--- a/src/collapse/__test__/__snapshots__/index.test.js.snap
+++ b/src/collapse/__test__/__snapshots__/index.test.js.snap
@@ -58,7 +58,6 @@ exports[`collapse :defaultExpandAll 1`] = `
                 class="t-cell__right t-class-right"
               >
                 <t-icon
-                  class=""
                   tClass="t-cell__right-icon t-class-right-icon"
                   bind:click=""
                 >
@@ -145,7 +144,6 @@ exports[`collapse :defaultExpandAll 1`] = `
                 class="t-cell__right t-class-right"
               >
                 <t-icon
-                  class=""
                   tClass="t-cell__right-icon t-class-right-icon"
                   bind:click=""
                 >

--- a/src/common/template/badge.wxml
+++ b/src/common/template/badge.wxml
@@ -9,7 +9,7 @@
     shape="{{shape || 'circle'}}"
     show-zero="{{showZero || false}}"
     size="{{size || 'medium'}}"
-    t-class="{{class}} {{tClass}}"
+    t-class="{{tClass}}"
     t-class-content="{{tClassContent}}"
     t-class-count="{{tClassCount}}"
   />

--- a/src/common/template/button.wxml
+++ b/src/common/template/button.wxml
@@ -2,8 +2,8 @@
   <t-button
     t-id="{{tId || ''}}"
     block="{{block || false}}"
-    class="{{class || ''}}"
-    t-class="{{externalClass}}"
+    class="{{rootClass || ''}}"
+    t-class="{{tClass}}"
     disabled="{{disabled || false}}"
     data-type="{{type}}"
     data-extra="{{extra}}"

--- a/src/common/template/icon.wxml
+++ b/src/common/template/icon.wxml
@@ -1,7 +1,6 @@
 <template name="icon">
   <t-icon
     style="{{style || ''}}"
-    class="{{class}}"
     t-class="{{tClass}}"
     prefix="{{prefix || ''}}"
     name="{{name || ''}}"

--- a/src/common/template/image.wxml
+++ b/src/common/template/image.wxml
@@ -1,6 +1,5 @@
 <template name="image">
   <t-image
-    class="{{class}}"
     t-class="{{tClass}}"
     t-class-load="{{tClassLoad}}"
     style="{{style || ''}}"

--- a/src/dialog/dialog.ts
+++ b/src/dialog/dialog.ts
@@ -54,8 +54,8 @@ export default class Dialog extends SuperComponent {
         const btn = buttonMap[key];
         const base: Record<string, any> = {
           block: true,
-          class: [...cls, `${classPrefix}__button--${key}`],
-          externalClass: [...externalCls, `${prefix}-class-${key}`],
+          rootClass: [...cls, `${classPrefix}__button--${key}`],
+          tClass: [...externalCls, `${prefix}-class-${key}`],
           variant: rect.buttonVariant,
           openType: '',
         };

--- a/src/dialog/dialog.wxml
+++ b/src/dialog/dialog.wxml
@@ -40,7 +40,7 @@
         <block wx:for="{{actions}}" wx:key="index">
           <template
             is="button"
-            data="{{block: true, type: 'action', extra: index, externalClass: prefix + '-class-action', class: this.getActionClass(classPrefix, buttonLayout), ...item }}"
+            data="{{block: true, type: 'action', extra: index, tClass: prefix + '-class-action', rootClass: this.getActionClass(classPrefix, buttonLayout), ...item }}"
           />
         </block>
       </block>

--- a/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
+++ b/src/dropdown-menu/__test__/__snapshots__/index.test.js.snap
@@ -26,7 +26,6 @@ exports[`dropdown-menu :base 1`] = `
           菜单
         </wx-view>
         <t-icon
-          class=""
           tClass="t-dropdown-menu__icon t-dropdown-menu__icon--active t-class-icon"
           bind:click=""
         >
@@ -59,7 +58,6 @@ exports[`dropdown-menu :base 1`] = `
           单列多选
         </wx-view>
         <t-icon
-          class=""
           tClass="t-dropdown-menu__icon t-dropdown-menu__icon-- t-class-icon"
           bind:click=""
         >

--- a/src/empty/empty.wxml
+++ b/src/empty/empty.wxml
@@ -8,7 +8,7 @@
     <template
       wx:elif="{{iconName || _.isNoEmptyObj(iconData)}}"
       is="icon"
-      data="{{class: classPrefix + '__icon', name: iconName, ...iconData}}"
+      data="{{tClass: classPrefix + '__icon', name: iconName, ...iconData}}"
     />
     <slot wx:else name="image" />
   </view>

--- a/src/fab/fab.ts
+++ b/src/fab/fab.ts
@@ -10,7 +10,7 @@ const baseButtonProps = {
   size: 'large',
   shape: 'circle',
   theme: 'primary',
-  externalClass: `${prefix}-fab__button`,
+  tClass: `${prefix}-fab__button`,
 };
 
 @wxComponent()

--- a/src/grid-item/grid-item.wxml
+++ b/src/grid-item/grid-item.wxml
@@ -50,7 +50,7 @@
           <template
             wx:if="{{iconName || _.isNoEmptyObj(iconData)}}"
             is="icon"
-            data="{{class: classPrefix + '__icon', name: iconName, ...iconData}}"
+            data="{{tClass: classPrefix + '__icon', name: iconName, ...iconData}}"
           />
         </view>
       </t-badge>

--- a/src/input/__test__/__snapshots__/index.test.js.snap
+++ b/src/input/__test__/__snapshots__/index.test.js.snap
@@ -71,7 +71,6 @@ exports[`input props : clearable && label && suffix 1`] = `
           bind:tap="clearInput"
         >
           <t-icon
-            class=""
             tClass="t-class-clearable"
             bind:click=""
           >
@@ -102,7 +101,6 @@ exports[`input props : clearable && label && suffix 1`] = `
           bind:tap="onSuffixIconClick"
         >
           <t-icon
-            class=""
             tClass="t-class-suffix-icon"
             bind:click=""
           >

--- a/src/message/__test__/__snapshots__/index.test.js.snap
+++ b/src/message/__test__/__snapshots__/index.test.js.snap
@@ -22,7 +22,6 @@ exports[`message props : style && customStyle 1`] = `
           class="t-message__icon--left"
         >
           <t-icon
-            class=""
             tClass="t-class-icon"
             bind:click=""
           >
@@ -58,7 +57,6 @@ exports[`message props : style && customStyle 1`] = `
           bind:tap="handleClose"
         >
           <t-icon
-            class=""
             tClass="t-class-close-btn"
             bind:click=""
           >

--- a/src/notice-bar/__test__/__snapshots__/index.test.js.snap
+++ b/src/notice-bar/__test__/__snapshots__/index.test.js.snap
@@ -14,7 +14,6 @@ exports[`notice-bar props : marquee 1`] = `
         bind:tap="clickPrefixIcon"
       >
         <t-icon
-          class=""
           tClass="t-class-prefix-icon"
           bind:click=""
         >

--- a/src/progress/progress.wxml
+++ b/src/progress/progress.wxml
@@ -27,7 +27,7 @@
       <template
         wx:if="{{_.includes(this.STATUS, status)}}"
         is="icon"
-        data="{{class: classPrefix + '__icon', size:'44rpx', name: this.LINE_STATUS_ICON[status]}}"
+        data="{{tClass: classPrefix + '__icon', size:'44rpx', name: this.LINE_STATUS_ICON[status]}}"
       ></template>
       <text wx:else>{{ _.isString(label)? label: computedProgress + '%' }}</text>
     </view>
@@ -86,7 +86,7 @@
           <template
             wx:if="{{_.includes(this.STATUS, status)}}"
             is="icon"
-            data="{{class: classPrefix + '__icon', size:'96rpx', name: this.CIRCLE_STATUS_ICON[status]}}"
+            data="{{tClass: classPrefix + '__icon', size:'96rpx', name: this.CIRCLE_STATUS_ICON[status]}}"
           ></template>
           <text wx:else>{{ _.isString(label)? label: computedProgress + '%' }}</text>
         </view>

--- a/src/result/result.wxml
+++ b/src/result/result.wxml
@@ -7,7 +7,7 @@
 >
   <view aria-hidden="true" class="{{classPrefix}}__thumb">
     <t-image wx:if="{{image}}" t-class="{{prefix}}-class-image" src="{{image}}" mode="aspectFit" />
-    <template wx:elif="{{_icon}}" is="icon" data="{{class: classPrefix + '__icon', ..._icon }}" />
+    <template wx:elif="{{_icon}}" is="icon" data="{{tClass: classPrefix + '__icon', ..._icon }}" />
     <slot name="image" />
   </view>
 

--- a/src/side-bar-item/side-bar-item.wxml
+++ b/src/side-bar-item/side-bar-item.wxml
@@ -17,7 +17,7 @@
     <view class="{{classPrefix}}__prefix"></view>
     <view class="{{classPrefix}}__suffix"></view>
   </block>
-  <template wx:if="{{_icon}}" is="icon" data="{{ class: classPrefix + '__icon', ..._icon }}" />
+  <template wx:if="{{_icon}}" is="icon" data="{{ tClass: classPrefix + '__icon', ..._icon }}" />
   <block wx:if="{{badgeProps}}">
     <template is="badge" data="{{ ...badgeProps, content: label }}" />
   </block>

--- a/src/swipe-cell/swipe-cell.wxml
+++ b/src/swipe-cell/swipe-cell.wxml
@@ -32,7 +32,7 @@
         <template
           wx:if="{{item.icon}}"
           is="icon"
-          data="{{class: classPrefix + '__icon', name: item.icon, ...item.icon}}"
+          data="{{tClass: classPrefix + '__icon', name: item.icon, ...item.icon}}"
         ></template>
         <text wx:if="{{item.text}}" class="{{classPrefix}}__text">{{item.text}}</text>
       </view>
@@ -51,7 +51,7 @@
         <template
           wx:if="{{item.icon}}"
           is="icon"
-          data="{{class: classPrefix + '__icon', name: item.icon, ...item.icon}}"
+          data="{{tClass: classPrefix + '__icon', name: item.icon, ...item.icon}}"
         ></template>
         <text wx:if="{{item.text}}" class="{{classPrefix}}__text">{{item.text}}</text>
       </view>

--- a/src/swiper/index.wxs
+++ b/src/swiper/index.wxs
@@ -7,7 +7,7 @@ function isNext(current, index, list) {
 }
 
 function getImageClass(prefix, current, index, list) {
-  var arr = [prefix + '-swiper__image', prefix + '-class-image'];
+  var arr = [prefix + '-swiper__image-host', prefix + '-swiper__image', prefix + '-class-image'];
 
   if (isPrev(current, index, list)) {
     arr.push(prefix + '-class-prev-image');

--- a/src/swiper/swiper.wxml
+++ b/src/swiper/swiper.wxml
@@ -32,7 +32,7 @@
     >
       <template
         is="image"
-        data="{{ class: classPrefix + '__image-host', tClass: this.getImageClass(prefix, navCurrent, index, list), style: 'height: ' + _.addUnit(height), src: _.isObject(item) ? item.value : item, mode: 'aspectFill', dataset: index, ...imageProps, bindload: 'onImageLoad' }}"
+        data="{{tClass: this.getImageClass(prefix, navCurrent, index, list), style: 'height: ' + _.addUnit(height), src: _.isObject(item) ? item.value : item, mode: 'aspectFill', dataset: index, ...imageProps, bindload: 'onImageLoad' }}"
       />
     </swiper-item>
   </swiper>

--- a/src/tabs/tabs.wxml
+++ b/src/tabs/tabs.wxml
@@ -43,7 +43,7 @@
               class="{{_.cls(classPrefix + '__item-inner', [theme, ['active', currentIndex === index]])}}"
               aria-hidden="{{ item.badgeProps.dot || item.badgeProps.count }}"
             >
-              <template wx:if="{{item.icon}}" is="icon" data="{{ class: classPrefix + '__icon', ...item.icon }}" />
+              <template wx:if="{{item.icon}}" is="icon" data="{{ tClass: classPrefix + '__icon', ...item.icon }}" />
               <block wx:if="{{item.badgeProps}}">
                 <template is="badge" data="{{ ...item.badgeProps, content: item.label }}" />
               </block>

--- a/src/tag/tag.wxml
+++ b/src/tag/tag.wxml
@@ -16,7 +16,7 @@
   <template
     wx:if="{{_closable}}"
     is="icon"
-    data="{{class: classPrefix + '__icon-close', tClass: prefix + '-icon', bindclick: 'handleClose',  ariaRole: 'button', ariaLabel: '关闭',  ..._closable }}"
+    data="{{tClass: classPrefix + '__icon-close ' + prefix + '-icon', bindclick: 'handleClose',  ariaRole: 'button', ariaLabel: '关闭',  ..._closable }}"
     catch:tap="handleClose"
   />
   <slot wx:else name="closable" />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3377 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景： Mpx + tdesign-miniprogram 编译报错
原因：tdesign-miniprogram 中， class 是外部样式类， 用于处理开启组件虚拟节点场景问题。 Mpx 会把 class  作为关键字处理，导致编译报错。

方案：对 class 关键字进行移除 or 重命名。
1. button 模版中，涉及到（dialog、calendar）单元测试，保留class，并将其重命名为 rootClass。
2. 其他template模版，对 class 进行移除处理，如有需要，请改用 tClass。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- other(Mpx): 修复在 `Mpx` 框架中编译报错问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
