### PR TITLE
fix(action-sheet): fix inconsistency between type definition and documentation

### DIFF
--- a/src/action-sheet/show.ts
+++ b/src/action-sheet/show.ts
@@ -1,12 +1,7 @@
 import { getInstance } from '../common/utils';
+import { ActionSheetItem } from './type';
 
-export interface ActionSheetItem {
-  label: string;
-  color?: string;
-  disabled?: boolean;
-  /** 图标名称或图片链接 */
-  icon?: string;
-}
+export { ActionSheetItem };
 
 type Context = WechatMiniprogram.Page.TrivialInstance | WechatMiniprogram.Component.TrivialInstance;
 


### PR DESCRIPTION

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案

#### 问题描述
在当前实现中，`ActionSheetItem` 接口同时在 `src/action-sheet/show.ts` 和 `src/action-sheet/type.ts` 文件中定义，这导致了类型定义与文档中提供的不一致:

https://github.com/Tencent/tdesign-miniprogram/blob/962fe6ee3b69ee927873ee831f098588f93775da/src/action-sheet/show.ts#L3-L9

https://github.com/Tencent/tdesign-miniprogram/blob/81700eb2de2b5c87786dc133d349c3c838963053/src/action-sheet/type.ts#L108-L114

#### 修改内容

- 从 `src/action-sheet/show.ts` 文件中移除了 `ActionSheetItem` 接口的定义

- 改为从 `type.ts` 文件中导入 `ActionSheetItem` 接口并重新导出

- 保持了接口的功能和使用方式不变

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
