### PR TITLE
fix(PullDownRefresh): 修复配置scroll-into-view不生效问题

### DIFF
--- a/src/pull-down-refresh/pull-down-refresh.ts
+++ b/src/pull-down-refresh/pull-down-refresh.ts
@@ -1,7 +1,8 @@
-import { SuperComponent, wxComponent, RelationsOptions } from '../common/src/index';
+import { RelationsOptions, SuperComponent, wxComponent } from '../common/src/index';
 import config from '../common/config';
 import props from './props';
-import { unitConvert, systemInfo, getRect } from '../common/utils';
+import { getRect, systemInfo, unitConvert } from '../common/utils';
+import { canUseProxyScrollView } from '../common/version';
 
 const { prefix } = config;
 const name = `${prefix}-pull-down-refresh`;
@@ -26,7 +27,7 @@ export default class PullDownRefresh extends SuperComponent {
 
   externalClasses = [`${prefix}-class`, `${prefix}-class-loading`, `${prefix}-class-text`, `${prefix}-class-indicator`];
 
-  behaviors = ['wx://proxy-scroll-view'];
+  behaviors = canUseProxyScrollView() ? ['wx://proxy-scroll-view'] : [];
 
   options = {
     multipleSlots: true,

--- a/src/pull-down-refresh/pull-down-refresh.ts
+++ b/src/pull-down-refresh/pull-down-refresh.ts
@@ -26,6 +26,8 @@ export default class PullDownRefresh extends SuperComponent {
 
   externalClasses = [`${prefix}-class`, `${prefix}-class-loading`, `${prefix}-class-text`, `${prefix}-class-indicator`];
 
+  behaviors = ['wx://proxy-scroll-view'];
+
   options = {
     multipleSlots: true,
     pureDataPattern: /^_/,


### PR DESCRIPTION
#2387

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #2387
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(PullDownRefresh): 修复配置 `scroll-into-view` 不生效问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
