### PR TITLE
chore: color-picker example adapts to dark mode

### DIFF
--- a/src/color-picker/__test__/__snapshots__/demo.test.js.snap
+++ b/src/color-picker/__test__/__snapshots__/demo.test.js.snap
@@ -18,7 +18,7 @@ exports[`ColorPicker ColorPicker format demo works fine 1`] = `
         catch:tap="clickFormat"
       >
         <t-icon
-          customStyle="position: absolute;left: 4rpx;top: 4rpx;z-index: 1;color: #fff"
+          customStyle="position: absolute; top: 4rpx; left: 4rpx; color: #fff; z-index: 1;"
           name="check"
           size="14"
         />

--- a/src/color-picker/_example/format/index.js
+++ b/src/color-picker/_example/format/index.js
@@ -2,6 +2,10 @@ Component({
   data: {
     curFormat: 'CSS',
     color: '#7bd60b',
+    formatList: [
+      ['CSS', 'HEX', 'RGB'],
+      ['HSL', 'HSV', 'CMYK'],
+    ],
   },
   methods: {
     onChange(e) {

--- a/src/color-picker/_example/format/index.wxml
+++ b/src/color-picker/_example/format/index.wxml
@@ -1,8 +1,8 @@
 <view>
-  <view class="format-line">
+  <view class="format-line" wx:for="{{formatList}}" wx:for-item="list" wx:key="index">
     <view
       class="format-item {{ curFormat === item ? 'active' : '' }}"
-      wx:for="{{['CSS', 'HEX', 'RGB']}}"
+      wx:for="{{list}}"
       wx:key="item"
       data-format="{{item}}"
       catch:tap="clickFormat"
@@ -11,24 +11,7 @@
         wx:if="{{curFormat === item}}"
         name="check"
         size="14"
-        custom-style="position: absolute;left: 4rpx;top: 4rpx;z-index: 1;color: #fff"
-      />
-      {{item}}
-    </view>
-  </view>
-  <view class="format-line">
-    <view
-      class="format-item {{ curFormat === item ? 'active' : '' }}"
-      wx:for="{{['HSL', 'HSV', 'CMYK']}}"
-      wx:key="item"
-      data-format="{{item}}"
-      catch:tap="clickFormat"
-    >
-      <t-icon
-        wx:if="{{curFormat === item}}"
-        name="check"
-        size="14"
-        custom-style="position: absolute;left: 4rpx;top: 4rpx;z-index: 1;color: #fff"
+        custom-style="position: absolute; top: 4rpx; left: 4rpx; color: #fff; z-index: 1;"
       />
       {{item}}
     </view>

--- a/src/color-picker/_example/format/index.wxss
+++ b/src/color-picker/_example/format/index.wxss
@@ -7,22 +7,22 @@
 }
 
 .format-item {
-  border-radius: 12rpx;
-  height: 100%;
-  background-color: #fff;
-  padding: 32rpx;
-  line-height: 100%;
-  width: 100%;
-  box-sizing: border-box;
-  position: relative;
-  overflow: hidden;
-
   display: flex;
   align-items: center;
+  position: relative;
+  padding: 32rpx;
+  width: 100%;
+  height: 100%;
+  line-height: 100%;
+  background-color: var(--td-bg-color-container);
+  border: 3rpx solid var(--td-bg-color-container);
+  border-radius: 12rpx;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .format-item.active {
-  border: 3rpx solid #0052d9;
+  border-color: var(--td-brand-color);
 }
 
 .format-item.active::after {
@@ -33,7 +33,7 @@
   left: 0;
   top: 0;
   border-top-left-radius: 12rpx;
-  border-top: 56rpx solid #0052d9;
+  border-top: 56rpx solid var(--td-brand-color);
   border-right: 56rpx solid transparent;
   border-radius: 0;
 }


### PR DESCRIPTION
before: 
![image](https://github.com/user-attachments/assets/64ce98a0-704d-4692-adeb-fc0cf16ddfd5)

after: 
![image](https://github.com/user-attachments/assets/5d2731d4-09bc-4cd3-85a7-7f1cba89d148)
