### PR TITLE
fix(link): disabled style condition judgment is missing

### DIFF
--- a/src/link/link.ts
+++ b/src/link/link.ts
@@ -59,7 +59,7 @@ export default class Link extends SuperComponent {
         classList.push(`${name}--underline`);
       }
       if (
-        (navigatorProps && !navigatorProps.url && !['navigateBack', 'exit'].includes(navigatorProps.openType)) ||
+        (navigatorProps && !navigatorProps.url && !navigatorProps.appId && !navigatorProps.shortLink && !['navigateBack', 'exit'].includes(navigatorProps.openType)) ||
         disabled
       ) {
         classList.push(`${name}--disabled`);

--- a/src/link/link.ts
+++ b/src/link/link.ts
@@ -55,13 +55,13 @@ export default class Link extends SuperComponent {
     setClass() {
       const { theme, size, underline, navigatorProps, disabled } = this.properties;
       const classList = [name, `${name}--${theme}`, `${name}--${size}`];
+      const { url, appId, shortLink, target, openType } = navigatorProps ?? {};
+      const condition = !(url || (target === 'miniProgram' && (appId || shortLink)));
+
       if (underline) {
         classList.push(`${name}--underline`);
       }
-      if (
-        (navigatorProps && !navigatorProps.url && !navigatorProps.appId && !navigatorProps.shortLink && !['navigateBack', 'exit'].includes(navigatorProps.openType)) ||
-        disabled
-      ) {
+      if ((navigatorProps && condition && !['navigateBack', 'exit'].includes(openType)) || disabled) {
         classList.push(`${name}--disabled`);
       }
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[navigator](https://developers.weixin.qq.com/miniprogram/dev/component/navigator.html) 的 `open-type="navigate"` 时，也可以通过指定 `app-id` 或者 `short-link` 跳转到其他小程序。目前只检查了 `url` 参数，会造成需要跳转到小程序的 `link` 的样式为 `disabled`。

### 💡 需求背景和解决方案

增加检查 `navigatorProps` 中的 `appId` 和 `shortLink` 参数。

### 📝 更新日志

- fix(Link): 修复在 `navigatorProps` 中只指定 `appId` 或者 `shortLink` 且 `target="miniProgram"` 时样式为禁用状态的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
