### PR TITLE
fix(Tabs): fixed line width calculation error when bottomLineMode is auto or full

### DIFF
--- a/src/tabs/tabs.wxs
+++ b/src/tabs/tabs.wxs
@@ -11,15 +11,16 @@ function animate(options) {
 }
 
 function trackStyle(options) {
-  if (options.distance) {
+  if (options.distance || options.lineWidth) {
     return utils._style({
       '-webkit-transform': 'translateX(' + options.distance + 'px)',
       transform: 'translateX(' + options.distance + 'px)',
       'transition-duration': options.isInit ? '0' : '0.3s',
-      width: options.lineWidth,
+      width: options.lineWidth + 'px',
       opacity: 1,
     });
   }
+
   return '';
 }
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 修复 1.8.8 中 `bottomLineMode` 为 `auto/full` 时线宽计算错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
