### PR TITLE
chore(TreeSelect): allow children to be undefined

### DIFF
--- a/src/tree-select/README.en-US.md
+++ b/src/tree-select/README.en-US.md
@@ -10,7 +10,7 @@ style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
 custom-value | String / Number / Array | - | Typescript：`TreeSelectValue` | N
 height | String / Number | 336 | \- | N
-keys | Object | - | alias filed name in data。Typescript：`KeysType`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
+keys | Object | - | alias filed name in options。Typescript：`TreeKeysType`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 multiple | Boolean | false | \- | N
 options | Array | [] | Typescript：`Array<DataOption>` | N
 value | String / Number / Array | - | Typescript：`TreeSelectValue` `type TreeSelectValue = string \| number \| Array<TreeSelectValue>`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/tree-select/type.ts) | N

--- a/src/tree-select/README.en-US.md
+++ b/src/tree-select/README.en-US.md
@@ -40,8 +40,10 @@ The component provides the following CSS variables, which can be used to customi
 Name | Default Value | Description 
 -- | -- | --
 --td-tree-bg-color | @bg-color-container | - 
+--td-tree-colum-text-color | @text-color-primary | - 
 --td-tree-colum-width | 206rpx | - 
 --td-tree-item-active-color | @brand-color | - 
+--td-tree-item-disabled-color | @text-color-disabled | - 
 --td-tree-item-font-size | 32rpx | - 
 --td-tree-item-height | 112rpx | - 
---td-tree-root-bg-color | @bg-color-secondarycontainer | -
+--td-tree-root-bg-color | @bg-color-secondarycontainer | - 

--- a/src/tree-select/README.md
+++ b/src/tree-select/README.md
@@ -56,7 +56,7 @@ style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
 custom-value | String / Number / Array | - | 自定义选中值，优先级高于 `value`。TS 类型：`TreeSelectValue` | N
 height | String / Number | 336 | 高度，默认单位为 px | N
-keys | Object | - | 用来定义 value / label 在 `options` 中对应的字段别名。TS 类型：`KeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
+keys | Object | - | 用来定义 `value / label / disabled / children` 在 `options` 数据中对应的字段别名，示例：`{ value: 'key', label: 'name', children: 'list' }`。TS 类型：`TreeKeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 multiple | Boolean | false | 是否允许多选 | N
 options | Array | [] | 选项。TS 类型：`Array<DataOption>` | N
 value | String / Number / Array | - | 选中值。TS 类型：`TreeSelectValue` `type TreeSelectValue = string \| number \| Array<TreeSelectValue>`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/tree/develop/src/tree-select/type.ts) | N

--- a/src/tree-select/README.md
+++ b/src/tree-select/README.md
@@ -86,8 +86,10 @@ t-class-right-item-label | 右侧第一列子项标签样式类
 名称 | 默认值 | 描述 
 -- | -- | --
 --td-tree-bg-color | @bg-color-container | - 
+--td-tree-colum-text-color | @text-color-primary | - 
 --td-tree-colum-width | 206rpx | - 
 --td-tree-item-active-color | @brand-color | - 
+--td-tree-item-disabled-color | @text-color-disabled | - 
 --td-tree-item-font-size | 32rpx | - 
 --td-tree-item-height | 112rpx | - 
---td-tree-root-bg-color | @bg-color-secondarycontainer | -
+--td-tree-root-bg-color | @bg-color-secondarycontainer | - 

--- a/src/tree-select/props.ts
+++ b/src/tree-select/props.ts
@@ -15,7 +15,7 @@ const props: TdTreeSelectProps = {
     type: null,
     value: 336,
   },
-  /** 用来定义 value / label 在 `options` 中对应的字段别名 */
+  /** 用来定义 `value / label / disabled / children` 在 `options` 数据中对应的字段别名，示例：`{ value: 'key', label: 'name', children: 'list' }` */
   keys: {
     type: Object,
   },

--- a/src/tree-select/tree-select.less
+++ b/src/tree-select/tree-select.less
@@ -3,6 +3,7 @@
 @tree-bg-color: var(--td-tree-bg-color, @bg-color-container);
 @tree-root-bg-color: var(--td-tree-root-bg-color, @bg-color-secondarycontainer);
 @tree-item-active-color: var(--td-tree-item-active-color, @brand-color);
+@tree-item-disabled-color: var(--td-tree-item-disabled-color, @text-color-disabled);
 @tree-item-height: var(--td-tree-item-height, 112rpx);
 @tree-item-font-size: var(--td-tree-item-font-size, 32rpx);
 @tree-colum-width: var(--td-tree-colum-width, 206rpx);
@@ -43,6 +44,12 @@
     &--active {
       font-weight: 600;
       color: @tree-item-active-color;
+    }
+
+    &--disabled {
+      pointer-events: none;
+      cursor: not-allowed;
+      color: @tree-item-disabled-color;
     }
   }
 

--- a/src/tree-select/tree-select.ts
+++ b/src/tree-select/tree-select.ts
@@ -67,7 +67,8 @@ export default class TreeSelect extends SuperComponent {
         const currentLevelOptions = currentNode.children.map((item: TreeOptionData) => ({
           label: item[keys?.label || 'label'],
           value: item[keys?.value || 'value'],
-          children: item.children,
+          disabled: item[keys?.disabled || 'disabled'],
+          children: item[keys?.children || 'children'],
         }));
 
         treeOptions.push(currentLevelOptions);

--- a/src/tree-select/tree-select.ts
+++ b/src/tree-select/tree-select.ts
@@ -30,14 +30,7 @@ export default class TreeSelect extends SuperComponent {
     scrollIntoView: null,
   };
 
-  properties = {
-    ...props,
-    customValue: {
-      // 用于自定义选中值，优先级高于value，用于弥补value为[]场景
-      type: null,
-      value: null,
-    },
-  };
+  properties = props;
 
   controlledProps = [
     {
@@ -60,50 +53,48 @@ export default class TreeSelect extends SuperComponent {
 
   methods = {
     buildTreeOptions() {
-      const { options, value, defaultValue, customValue, multiple, keys } = this.data;
-      const treeOptions = [];
+      const { options, value, customValue, multiple, keys } = this.data;
+
+      if (!options.length) return;
+
+      const treeOptions: TreeOptionData[][] = [];
 
       let level = -1;
-      let node = { children: options };
+      let currentNode = { children: options };
 
-      if (options.length === 0) return;
-
-      while (node && node.children) {
+      while (currentNode?.children) {
         level += 1;
-        const list = node.children.map((item: TreeOptionData) => ({
+        const currentLevelOptions = currentNode.children.map((item: TreeOptionData) => ({
           label: item[keys?.label || 'label'],
           value: item[keys?.value || 'value'],
           children: item.children,
         }));
-        const thisValue = customValue?.[level] || value?.[level];
 
-        treeOptions.push([...list]);
+        treeOptions.push(currentLevelOptions);
 
-        if (thisValue == null) {
-          const [firstChild] = list;
-          node = firstChild;
-        } else {
-          const child = list.find((child) => child.value === thisValue);
-          node = child ?? list[0];
-        }
+        const currentValue = customValue?.[level] ?? value?.[level];
+        currentNode = currentValue
+          ? currentLevelOptions.find((child) => child.value === currentValue) ?? currentLevelOptions[0]
+          : currentLevelOptions[0];
+      }
+
+      // Ensure at least two levels (even if second is empty)
+      if (treeOptions.length === 1) {
+        treeOptions.push([]);
+        level += 1;
       }
 
       const leafLevel = Math.max(0, level);
-
-      if (multiple) {
-        const finalValue = customValue || value || defaultValue;
-        if (finalValue[leafLevel] != null && !Array.isArray(finalValue[leafLevel])) {
-          throw TypeError('应传入数组类型的 value');
-        }
-      }
+      const innerValue =
+        customValue ||
+        treeOptions.map((levelOptions, idx) => {
+          const isLastLevel = idx === treeOptions.length - 1;
+          const defaultValue = isLastLevel && multiple ? [levelOptions[0]?.value] : levelOptions[0]?.value;
+          return value?.[idx] ?? defaultValue;
+        });
 
       this.setData({
-        innerValue:
-          customValue ||
-          treeOptions?.map((ele, idx) => {
-            const v = idx === treeOptions.length - 1 && multiple ? [ele[0].value] : ele[0].value;
-            return value?.[idx] || v;
-          }),
+        innerValue,
         leafLevel,
         treeOptions,
       });

--- a/src/tree-select/tree-select.wxml
+++ b/src/tree-select/tree-select.wxml
@@ -20,6 +20,7 @@
         wx:key="index"
         label="{{item.label}}"
         value="{{item.value}}"
+        disabled="{{item.disabled}}"
         tId="scroll-to-{{item.value}}"
         class="scroll-into-view"
         t-class="{{prefix}}-class-left-item"
@@ -32,7 +33,7 @@
         bind:tap="handleTreeClick"
         data-level="{{level}}"
         data-value="{{item.value}}"
-        class="{{_.cls(classPrefix + '__item', [['active', item.value === innerValue[level]]])}} {{prefix}}-class-middle-item scroll-into-view"
+        class="{{_.cls(classPrefix + '__item', [['active', item.value === innerValue[level]], ['disabled', item.disabled]])}} {{prefix}}-class-middle-item scroll-into-view"
       >
         <view id="scroll-to-{{item.value}}"> {{item.label}} </view>
       </view>
@@ -53,6 +54,7 @@
         t-class-label="{{prefix}}-class-right-item-label"
         icon="line"
         value="{{item.value}}"
+        disabled="{{item.disabled}}"
         maxLabelRow="{{1}}"
         borderless
         placement="right"
@@ -71,14 +73,15 @@
       <t-checkbox
         wx:for="{{treeOptions[level]}}"
         wx:key="value"
-        placement="right"
-        icon="line"
-        maxLabelRow="{{1}}"
         tId="scroll-to-{{item.value}}"
         class="scroll-into-view {{prefix}}-class-right-item"
         t-class-label="{{prefix}}-class-right-item-label"
-        borderless
+        placement="right"
+        icon="line"
+        maxLabelRow="{{1}}"
         value="{{item.value}}"
+        disabled="{{item.disabled}}"
+        borderless
       >
         {{item.label}}
       </t-checkbox>

--- a/src/tree-select/type.ts
+++ b/src/tree-select/type.ts
@@ -4,7 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
-import { TreeOptionData, KeysType } from '../common/common';
+import { TreeOptionData, TreeKeysType } from '../common/common';
 
 export interface TdTreeSelectProps<DataOption extends TreeOptionData = TreeOptionData> {
   /**
@@ -23,11 +23,11 @@ export interface TdTreeSelectProps<DataOption extends TreeOptionData = TreeOptio
     value?: string | number;
   };
   /**
-   * 用来定义 value / label 在 `options` 中对应的字段别名
+   * 用来定义 `value / label / disabled / children` 在 `options` 数据中对应的字段别名，示例：`{ value: 'key', label: 'name', children: 'list' }`
    */
   keys?: {
     type: ObjectConstructor;
-    value?: KeysType;
+    value?: TreeKeysType;
   };
   /**
    * 是否允许多选


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(TreeSelect):  允许 `options` 的 `children` 为 `undefined`，同时增强 `keys` 属性，支持为 `disabled / children` 字段自定义别名

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
