### PR TITLE
docs:  A new contributor graph that evaluates community activities from all dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ npm run dev
 
 ## 贡献成员
 
+<a href="https://openomy.app/github/tencent/tdesign-miniprogram" target="_blank" style="display: block; width: 100%;" align="center">
+  <img src="https://openomy.app/svg?repo=tencent/tdesign-miniprogram&chart=bubble&latestMonth=3" target="_blank" alt="Contribution Leaderboard" style="display: block; width: 100%;" />
+ </a>
+
+
 <a href="https://github.com/tencent/tdesign-miniprogram/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tencent/tdesign-miniprogram" />
 </a>


### PR DESCRIPTION
Hi Tencent/tdesign Community

tdesign-miniprogram is a vibrant open-source community where its products and frameworks are loved by tens of thousands of users and developers. As people use it, they contribute by raising issues, engaging in discussions, or directly contributing code, all of which help in continuously improving tdesign-miniprogram.

However, GitHub's default contributor list simply enumerates users who have committed code, failing to proportionately reflect the broader range of community contributors.

Therefore, we have designed a new chart that showcases active contributors from three perspectives: issues, PRs, and discussions. This is similar to embedding star-history within the README:

![Tencent/tdesign-miniprogram](https://www.openomy.app/svg?repo=Tencent/tdesign-miniprogram&chart=bubble&latestMonth=3)

By clicking on the link, you can view the specific contributions made by each individual: 

[Tencent/tdesign-miniprogram](https://www.openomy.app/github/Tencent/tdesign-miniprogram)

Currently, we have received recognition from communities such as [Ant Design (antd)]([GitHub - ant-design/ant-design: An enterprise-class UI design language and React UI library](https://github.com/ant-design/ant-design)). We aim to introduce this solution to more open-source communities and actively seek feedback for ongoing improvement.

We would greatly appreciate it if you could merge this PR. However, if you feel that the style is not appropriate or you don't like this approach, that's perfectly okay as well!