### PR TITLE
fix(Toast): fit-content is not supported under skyline

### DIFF
--- a/src/toast/_example/toast.less
+++ b/src/toast/_example/toast.less
@@ -6,10 +6,4 @@ page {
   .t-button {
     margin-bottom: 32rpx;
   }
-
-  .box {
-    display: block;
-    box-sizing: border-box;
-    padding: 0 32rpx;
-  }
 }

--- a/src/toast/_example/toast.wxml
+++ b/src/toast/_example/toast.wxml
@@ -5,16 +5,16 @@
     desc="用于轻量级反馈或提示，不会打断用户操作。"
     notice="渲染框架支持情况：Skyline、WebView"
   />
-  <t-demo title="01 组件类型" desc="基础提示">
-    <base class="box" />
+  <t-demo title="01 组件类型" desc="基础提示" padding>
+    <base />
   </t-demo>
-  <t-demo title="02 组件状态" desc="内置主题">
-    <theme class="box" />
+  <t-demo title="02 组件状态" desc="内置主题" padding>
+    <theme />
   </t-demo>
-  <t-demo title="03 显示遮罩" desc="弹窗可显示遮罩，禁止滑动和点击">
-    <cover class="box" />
+  <t-demo title="03 显示遮罩" desc="弹窗可显示遮罩，禁止滑动和点击" padding>
+    <cover />
   </t-demo>
-  <t-demo title="04 手动关闭" desc="手动关闭轻提示">
-    <close class="box" />
+  <t-demo title="04 手动关闭" desc="手动关闭轻提示" padding>
+    <close />
   </t-demo>
 </view>

--- a/src/toast/toast.less
+++ b/src/toast/toast.less
@@ -9,7 +9,6 @@
 
 .@{prefix}-toast {
   position: fixed;
-  right: -50%;
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 12001;
@@ -20,7 +19,11 @@
   font-size: 28rpx;
   color: @toast-color;
   max-width: @toast-max-width;
-  width: fit-content;
+  min-height: 0; // 防止 flex 容器被意外拉伸
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   box-sizing: border-box;
 
   &--column {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3707
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
skyline 不支持 fit-content，改用 flex 布局
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Toast): 使用 `flex` 替换 `fit-content`，兼容 `skyline` 场景

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
