### PR TITLE
chore: add css file compression rules

### DIFF
--- a/script/gulpfile.base.js
+++ b/script/gulpfile.base.js
@@ -215,7 +215,23 @@ module.exports = (src, dist, moduleName) => {
       .pipe(generateConfigReplaceTask(config, { stringify: false }))
       .pipe(gulpIf(!isProduction, sourcemaps.init()))
       .pipe(gulpLess()) // 编译less
-      .pipe(gulpIf(isComponentFolder(src) && isProduction, cssmin()))
+      .pipe(
+        gulpIf(
+          isComponentFolder(src) && isProduction,
+          cssmin({
+            compatibility: 'ie9',
+            format: {
+              semicolonAfterLastProperty: true,
+              breaks: {
+                afterAtRule: true,
+                afterRuleEnds: true,
+                afterBlockBegins: true,
+                afterBlockEnds: true,
+              },
+            },
+          }),
+        ),
+      )
       .pipe(
         gulpIf(
           isComponentFolder(src),


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题： 
TD旧版本（1.8.5）引用后编译正常，无此错误。

控制台报错信息：
app.less引用 @import '/miniprogram_npm/tdesign-miniprogram/common/style/theme/_index.wxss';
编译后出现语法错误：[ WXSS 文件编译错误] 
SyntaxError: media definitions require block statements after any features in D:\xx\miniprogram\miniprogram_npm\tdesign-miniprogram\common\style\theme\_index.wxss on line 1, column 37:(env: Windows,mp,1.06.2506102; lib: 3.7.12)

原因：
1. 媒体查询规则破坏
2. 结尾多处缺少分号


改动点：
新增 gulp-clean-css 压缩规则（1. 避免破坏 @media 规则；强制保留末尾分号）

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(build): 修复 `1.9.0` 版本在 `Windows` 环境下 `WXSS` 文件编译错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
