### PR TITLE
 fix(Grid): fix the border style error when the griditems is not an integer multiple of columns

### DIFF
--- a/src/grid-item/grid-item.ts
+++ b/src/grid-item/grid-item.ts
@@ -102,7 +102,7 @@ export default class GridItem extends SuperComponent {
   // 获取应该加在gridWrap上的padding
   getPaddingStyle() {
     const { gutter } = this.parent.properties;
-    if (gutter) return `padding-left:${gutter}rpx;padding-top:${gutter}rpx`;
+    if (gutter) return `padding-bottom:${gutter}rpx;padding-right:${gutter}rpx`;
     return '';
   }
 
@@ -114,7 +114,7 @@ export default class GridItem extends SuperComponent {
     if (!isObject(border)) border = {} as any;
     const { color = '#266FE8', width = 2, style = 'solid' } = border as any;
     if (gutter) return `border:${width}rpx ${style} ${color}`;
-    return `border-top:${width}rpx ${style} ${color};border-left:${width}rpx ${style} ${color}`;
+    return `border-bottom:${width}rpx ${style} ${color};border-right:${width}rpx ${style} ${color}`;
   }
 
   onClick(e) {

--- a/src/grid/__test__/index.test.js
+++ b/src/grid/__test__/index.test.js
@@ -26,13 +26,13 @@ describe('grid', () => {
     comp.attach(document.createElement('parent-wrapper'));
 
     const $content = comp.querySelector('#grid >>> .t-grid__content');
-    expect($content.dom.style.marginLeft).toBe('-4px');
+    expect($content.dom.style.marginRight).toBe('-4px');
 
     comp.setData({ border: true });
-    expect($content.dom.style.marginLeft).toBe('-2px');
+    expect($content.dom.style.marginRight).toBe('-2px');
 
     comp.setData({ border: {} });
-    expect($content.dom.style.marginLeft).toBe('-2px');
+    expect($content.dom.style.marginRight).toBe('-2px');
   });
 
   it(':gutter', () => {
@@ -42,7 +42,7 @@ describe('grid', () => {
     comp.setData({ gutter: 0 });
 
     const $content = comp.querySelector('#grid >>> .t-grid__content');
-    expect($content.dom.style.marginLeft).toBe('-0px');
+    expect($content.dom.style.marginRight).toBe('-0px');
   });
 
   it(':event', async () => {

--- a/src/grid/grid.ts
+++ b/src/grid/grid.ts
@@ -55,10 +55,10 @@ export default class Grid extends SuperComponent {
       const { gutter } = this.properties;
       let { border } = this.properties;
 
-      if (!border) return `margin-left:-${gutter}rpx; margin-top:-${gutter}rpx`;
+      if (!border) return `margin-bottom:-${gutter}rpx; margin-right:-${gutter}rpx`;
       if (!isObject(border)) border = {} as any;
       const { width = 2 } = border as any;
-      return `margin-left:-${width}rpx; margin-top:-${width}rpx`;
+      return `margin-bottom:-${width}rpx; margin-right:-${width}rpx`;
     },
   };
 }

--- a/src/upload/__test__/index.test.js
+++ b/src/upload/__test__/index.test.js
@@ -152,7 +152,7 @@ describe('upload', () => {
       const $gridItem = comp.querySelector('#t-upload >>> .t-grid-item');
       // gutter = 16, 单位 rpx
       expect($gridContent.dom.getAttribute('style')).toEqual(
-        `margin-left:-${comp.data.gutter}px; margin-top:-${comp.data.gutter}px`,
+        `margin-bottom:-${comp.data.gutter}px; margin-right:-${comp.data.gutter}px`,
       );
 
       // gridConfig: width、 height


### PR DESCRIPTION


### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3738
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Grid): 修复 `GridItem` 项数是 `columns` 列数的非整数倍时边框样式错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
