### PR TITLE
fix(ActionSheet): 页面跳转返回后再点击不显示问题

### DIFF
--- a/src/mixins/transition.ts
+++ b/src/mixins/transition.ts
@@ -71,6 +71,12 @@ export default function transition() {
         }, 30);
         if (typeof duration === 'number' && duration > 0) {
           this.transitionT = setTimeout(this.entered.bind(this), duration + 30);
+        } else {
+          setTimeout(() => {
+            if (this.status === 'entering') {
+              this.entered();
+            }
+          }, 300);
         }
       },
       entered() {
@@ -97,6 +103,12 @@ export default function transition() {
         if (typeof duration === 'number' && duration > 0) {
           this.customDuration = true;
           this.transitionT = setTimeout(this.leaved.bind(this), duration + 30);
+        } else {
+          setTimeout(() => {
+            if (this.status === 'leaving') {
+              this.leaved();
+            }
+          }, 300);
         }
       },
       leaved() {
@@ -106,6 +118,7 @@ export default function transition() {
         this.status = 'leaved';
         this.setData({
           transitionClass: '',
+          realVisible: false,
         });
       },
       onTransitionEnd() {
@@ -118,9 +131,6 @@ export default function transition() {
           this.entered();
         } else if (this.status === 'leaving' && !this.data.visible) {
           this.leaved();
-          this.setData({
-            realVisible: false,
-          });
         }
       },
     },

--- a/src/mixins/transition.ts
+++ b/src/mixins/transition.ts
@@ -57,7 +57,7 @@ export default function transition() {
         return [Number(durations), Number(durations)];
       },
       enter() {
-        const { name } = this.data;
+        const { name, transitionDurations } = this.data;
         const [duration] = this.durations;
         this.status = 'entering';
         this.setData({
@@ -72,11 +72,10 @@ export default function transition() {
         if (typeof duration === 'number' && duration > 0) {
           this.transitionT = setTimeout(this.entered.bind(this), duration + 30);
         } else {
-          setTimeout(() => {
-            if (this.status === 'entering') {
-              this.entered();
-            }
-          }, 300);
+          this.transitionT = setTimeout(
+            this.status === 'entering' ? this.entered.bind(this) : null,
+            transitionDurations + 30,
+          );
         }
       },
       entered() {
@@ -88,7 +87,7 @@ export default function transition() {
         });
       },
       leave() {
-        const { name } = this.data;
+        const { name, transitionDurations } = this.data;
         const [, duration] = this.durations;
         this.status = 'leaving';
         this.setData({
@@ -104,11 +103,10 @@ export default function transition() {
           this.customDuration = true;
           this.transitionT = setTimeout(this.leaved.bind(this), duration + 30);
         } else {
-          setTimeout(() => {
-            if (this.status === 'leaving') {
-              this.leaved();
-            }
-          }, 300);
+          this.transitionT = setTimeout(
+            this.status === 'leaving' ? this.leaved.bind(this) : null,
+            transitionDurations + 30,
+          );
         }
       },
       leaved() {

--- a/src/transition/__test__/index.test.js
+++ b/src/transition/__test__/index.test.js
@@ -41,32 +41,33 @@ describe('transition', () => {
       const [transitionDom] = transitionComp.dom.children;
 
       // enter
-      transitionComp.setData({ visible: true });
-      expect(transitionDom.style.display).toEqual('');
-      expect(transitionDom.className.match(/fade-enter\s/)).toBeTruthy();
-      expect(transitionDom.className.match(/fade-enter-active/)).toBeTruthy();
+      transitionComp.setData({ visible: true }, () => {
+        expect(transitionDom.style.display).toEqual('');
+        expect(transitionDom.className.match(/fade-enter\s/)).toBeTruthy();
+        expect(transitionDom.className.match(/fade-enter-active/)).toBeTruthy();
 
-      // enter to
-      jest.runAllTimers();
-      expect(transitionDom.className.match(/fade-enter-to/)).toBeTruthy();
+        // enter to
+        jest.runAllTimers();
+        expect(transitionDom.className.match(/fade-enter-to/)).toBeTruthy();
 
-      // enter finished
-      transitionComp.instance.onTransitionEnd();
-      expect(transitionDom.className.match(/fade-(enter|enter-to|enter-active)/)).toBeFalsy();
+        // enter finished
+        transitionComp.instance.onTransitionEnd();
+        expect(transitionDom.className.match(/fade-(enter|enter-to|enter-active)/)).toBeFalsy();
 
-      // leave
-      transitionComp.setData({ visible: false });
-      expect(transitionDom.className.match(/leave\s/)).toBeTruthy();
-      expect(transitionDom.className.match(/leave-active/)).toBeTruthy();
+        // leave
+        transitionComp.setData({ visible: false });
+        expect(transitionDom.className.match(/leave\s/)).toBeTruthy();
+        expect(transitionDom.className.match(/leave-active/)).toBeTruthy();
 
-      // leave to
-      jest.runAllTimers();
-      expect(transitionDom.className.match(/leave-to/)).toBeTruthy();
+        // leave to
+        jest.runAllTimers();
+        expect(transitionDom.className.match(/leave-to/)).toBeTruthy();
 
-      // leave finished
-      transitionComp.instance.onTransitionEnd();
-      expect(transitionDom.style.display).toEqual('none');
-      expect(transitionDom.className.match(/(leave|leave-to|leave-active)/)).toBeFalsy();
+        // leave finished
+        transitionComp.instance.onTransitionEnd();
+        expect(transitionDom.style.display).toEqual('none');
+        expect(transitionDom.className.match(/(leave|leave-to|leave-active)/)).toBeFalsy();
+      });
     });
 
     it(':name', () => {
@@ -74,11 +75,12 @@ describe('transition', () => {
       transitionComp.attach(document.createElement('parent-wrapper'));
       const [transitionDom] = transitionComp.dom.children;
 
-      transitionComp.setData({ visible: true });
-      jest.runAllTimers();
-      expect(transitionDom.className.match(/foo-enter/)).toBeTruthy();
-      expect(transitionDom.className.match(/foo-enter-active/)).toBeTruthy();
-      expect(transitionDom.className.match(/foo-enter-to/)).toBeTruthy();
+      transitionComp.setData({ visible: true }, () => {
+        jest.runAllTimers();
+        expect(transitionDom.className.match(/foo-enter/)).toBeTruthy();
+        expect(transitionDom.className.match(/foo-enter-active/)).toBeTruthy();
+        expect(transitionDom.className.match(/foo-enter-to/)).toBeTruthy();
+      });
     });
 
     // it(':destroyOnHide', () => {
@@ -93,13 +95,14 @@ describe('transition', () => {
     // });
 
     it(':appear', () => {
-      const transitionComp = simulate.render(transitionId, { visible: true, appear: true });
-      transitionComp.attach(document.createElement('parent-wrapper'));
-      const [transitionDom] = transitionComp.dom.children;
-      expect(transitionDom.className.match(/enter\s/)).toBeTruthy();
-      expect(transitionDom.className.match(/enter-active/)).toBeTruthy();
-      jest.runAllTimers();
-      expect(transitionDom.className.match(/enter-to/)).toBeTruthy();
+      const transitionComp = simulate.render(transitionId, { visible: true, appear: true }, () => {
+        transitionComp.attach(document.createElement('parent-wrapper'));
+        const [transitionDom] = transitionComp.dom.children;
+        expect(transitionDom.className.match(/enter\s/)).toBeTruthy();
+        expect(transitionDom.className.match(/enter-active/)).toBeTruthy();
+        jest.runAllTimers();
+        expect(transitionDom.className.match(/enter-to/)).toBeTruthy();
+      });
     });
 
     it(':durations', () => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#3567 
#1219 
#2798 

### 💡 需求背景和解决方案
需求背景：在 A 页面点击 ActionSheet 选项跳转到 B 页面，返回 A 页面后，安卓设备上点击 ActionSheet 无响应。以及偶现Toast已隐藏，但是页面无法点击。测试中发现ActionSheet和Toast的overlay未正常消失，导致后续点击失效。主要原因中是在动画执行过程中，transitionend 事件绑定的onTransitionEnd 方法偶现未触发。

 解决方案：增加兜底逻辑，确保动画结束后 overlay必然消失。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(actionsheet): 页面跳转返回后再点击不显示问题
- fix(toast)：修复toast已隐藏，页面无法点击问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
