### PR TITLE
fix(ImageViewer): correct the default value of the backgroundColor

### DIFF
--- a/script/generate-css-vars.js
+++ b/script/generate-css-vars.js
@@ -59,10 +59,10 @@ const generateCssVariables = async (componentName) => {
 
     const list = file.match(matchReg)?.sort();
 
-    list?.forEach((item) => {
+    list?.forEach((item, index) => {
       cssVariableBodyContent += `${item.slice(1, item.indexOf(',')).trim()} | ${item
         .slice(item.indexOf(',') + 2, item.length - 1)
-        .trim()} | - \n`;
+        .trim()} | -${index === list.length - 1 ? '' : ' \n'}`;
     });
   });
 

--- a/src/common/style/_variables.less
+++ b/src/common/style/_variables.less
@@ -191,4 +191,8 @@
 @position-fixed-top: var(--td-position-fixed-top, 0);
 
 // 遮罩
-@mask-bg: var(--td-mask-background); // 二维码遮罩
+@mask-active: var(--td-mask-active, rgba(0, 0, 0, 0.6)); // 遮罩-弹出
+@mask-disabled: var(--td-mask-disabled, rgba(255, 255, 255, 0.6)); // 遮罩-禁用
+@mask-bg: var(--td-mask-background, rgba(255, 255, 255, 0.96)); // 二维码遮罩
+
+@text-line-height: 1.5;

--- a/src/image-viewer/README.en-US.md
+++ b/src/image-viewer/README.en-US.md
@@ -32,9 +32,9 @@ delete | `(index: number)` | \-
 The component provides the following CSS variables, which can be used to customize styles.
 Name | Default Value | Description 
 -- | -- | --
---td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
+--td-image-viewer-mask-bg-color | @mask-active | - 
 --td-image-viewer-nav-bg-color | #000 | - 
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 

--- a/src/image-viewer/README.en-US.md
+++ b/src/image-viewer/README.en-US.md
@@ -8,7 +8,7 @@ name | type | default | description | required
 -- | -- | -- | -- | --
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
-background-color | String | 'rgba(0, 0, 0, 1)' | \- | N
+background-color | String | - | \- | N
 close-btn | String / Boolean / Object / Slot | false | [see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 delete-btn | String / Boolean / Object / Slot | false | [see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 images | Array | [] | Typescript：`Array<string>` | N
@@ -38,4 +38,4 @@ Name | Default Value | Description
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 
 --td-image-viewer-nav-index-font-size | @font-size-base | - 
---td-image-viewer-top | @position-fixed-top | - 
+--td-image-viewer-top | @position-fixed-top | -

--- a/src/image-viewer/README.en-US.md
+++ b/src/image-viewer/README.en-US.md
@@ -35,7 +35,7 @@ Name | Default Value | Description
 --td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
---td-image-viewer-nav-bg-color | @font-gray-3 | - 
+--td-image-viewer-nav-bg-color | #000 | - 
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 
 --td-image-viewer-nav-index-font-size | @font-size-base | - 

--- a/src/image-viewer/README.en-US.md
+++ b/src/image-viewer/README.en-US.md
@@ -32,6 +32,7 @@ delete | `(index: number)` | \-
 The component provides the following CSS variables, which can be used to customize styles.
 Name | Default Value | Description 
 -- | -- | --
+--td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
 --td-image-viewer-nav-bg-color | @font-gray-3 | - 

--- a/src/image-viewer/README.md
+++ b/src/image-viewer/README.md
@@ -81,7 +81,7 @@ delete | `(index: number)` | 点击删除操作按钮时触发
 --td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
---td-image-viewer-nav-bg-color | @font-gray-3 | - 
+--td-image-viewer-nav-bg-color | #000 | - 
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 
 --td-image-viewer-nav-index-font-size | @font-size-base | - 

--- a/src/image-viewer/README.md
+++ b/src/image-viewer/README.md
@@ -54,7 +54,7 @@ isComponent: true
 -- | -- | -- | -- | --
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
-background-color | String | 'rgba(0, 0, 0, 1)' | 遮罩的背景颜色 | N
+background-color | String | - | 遮罩的背景颜色 | N
 close-btn | String / Boolean / Object / Slot | false | 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 delete-btn | String / Boolean / Object / Slot | false | 是否显示删除操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `delete`，值为 `Object` 类型，表示透传至 `icon`，不传表示不显示图标。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/src/common/common.ts) | N
 images | Array | [] | 图片数组。TS 类型：`Array<string>` | N
@@ -84,4 +84,4 @@ delete | `(index: number)` | 点击删除操作按钮时触发
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 
 --td-image-viewer-nav-index-font-size | @font-size-base | - 
---td-image-viewer-top | @position-fixed-top | - 
+--td-image-viewer-top | @position-fixed-top | -

--- a/src/image-viewer/README.md
+++ b/src/image-viewer/README.md
@@ -78,9 +78,9 @@ delete | `(index: number)` | 点击删除操作按钮时触发
 组件提供了下列 CSS 变量，可用于自定义样式。
 名称 | 默认值 | 描述 
 -- | -- | --
---td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
+--td-image-viewer-mask-bg-color | @mask-active | - 
 --td-image-viewer-nav-bg-color | #000 | - 
 --td-image-viewer-nav-color | @text-color-anti | - 
 --td-image-viewer-nav-height | 96rpx | - 

--- a/src/image-viewer/README.md
+++ b/src/image-viewer/README.md
@@ -78,6 +78,7 @@ delete | `(index: number)` | 点击删除操作按钮时触发
 组件提供了下列 CSS 变量，可用于自定义样式。
 名称 | 默认值 | 描述 
 -- | -- | --
+--td-image-viewer-bg-color | @mask-active | - 
 --td-image-viewer-close-margin-left | @spacer-1 | - 
 --td-image-viewer-delete-margin-right | @spacer-1 | - 
 --td-image-viewer-nav-bg-color | @font-gray-3 | - 

--- a/src/image-viewer/image-viewer.less
+++ b/src/image-viewer/image-viewer.less
@@ -7,6 +7,7 @@
 @image-viewer-nav-height: var(--td-image-viewer-nav-height, 96rpx);
 @image-viewer-nav-bg-color: var(--td-image-viewer-nav-bg-color, @font-gray-3);
 @image-viewer-nav-color: var(--td-image-viewer-nav-color, @text-color-anti);
+@image-viewer-bg-color: var(--td-image-viewer-bg-color, @mask-active);
 @image-viewer-nav-index-font-size: var(--td-image-viewer-nav-index-font-size, @font-size-base);
 @image-viewer-close-margin-left: var(--td-image-viewer-close-margin-left, @spacer-1);
 @image-viewer-delete-margin-right: var(--td-image-viewer-delete-margin-right, @spacer-1);
@@ -29,6 +30,7 @@
     top: 0;
     width: 100%;
     height: 100%;
+    background-color: @image-viewer-bg-color;
   }
 
   &__content {

--- a/src/image-viewer/image-viewer.less
+++ b/src/image-viewer/image-viewer.less
@@ -5,7 +5,7 @@
 @image-viewer-icon-font-size: 48rpx;
 
 @image-viewer-nav-height: var(--td-image-viewer-nav-height, 96rpx);
-@image-viewer-nav-bg-color: var(--td-image-viewer-nav-bg-color, @font-gray-3);
+@image-viewer-nav-bg-color: var(--td-image-viewer-nav-bg-color, #000);
 @image-viewer-nav-color: var(--td-image-viewer-nav-color, @text-color-anti);
 @image-viewer-bg-color: var(--td-image-viewer-bg-color, @mask-active);
 @image-viewer-nav-index-font-size: var(--td-image-viewer-nav-index-font-size, @font-size-base);

--- a/src/image-viewer/image-viewer.less
+++ b/src/image-viewer/image-viewer.less
@@ -7,7 +7,7 @@
 @image-viewer-nav-height: var(--td-image-viewer-nav-height, 96rpx);
 @image-viewer-nav-bg-color: var(--td-image-viewer-nav-bg-color, #000);
 @image-viewer-nav-color: var(--td-image-viewer-nav-color, @text-color-anti);
-@image-viewer-bg-color: var(--td-image-viewer-bg-color, @mask-active);
+@image-viewer-mask-bg-color: var(--td-image-viewer-mask-bg-color, @mask-active);
 @image-viewer-nav-index-font-size: var(--td-image-viewer-nav-index-font-size, @font-size-base);
 @image-viewer-close-margin-left: var(--td-image-viewer-close-margin-left, @spacer-1);
 @image-viewer-delete-margin-right: var(--td-image-viewer-delete-margin-right, @spacer-1);
@@ -30,7 +30,7 @@
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: @image-viewer-bg-color;
+    background-color: @image-viewer-mask-bg-color;
   }
 
   &__content {

--- a/src/image-viewer/image-viewer.wxml
+++ b/src/image-viewer/image-viewer.wxml
@@ -16,7 +16,7 @@
     class="{{classPrefix}}__mask"
     data-source="overlay"
     bind:tap="onClose"
-    style="{{ '--td-image-viewer-bg-color: ' + backgroundColor }}"
+    style="{{ '--td-image-viewer-mask-bg-color: ' + backgroundColor }}"
     aria-role="button"
     aria-label="关闭"
   />

--- a/src/image-viewer/image-viewer.wxml
+++ b/src/image-viewer/image-viewer.wxml
@@ -16,7 +16,7 @@
     class="{{classPrefix}}__mask"
     data-source="overlay"
     bind:tap="onClose"
-    style="{{ 'background-color: ' + backgroundColor }}"
+    style="{{ '--td-image-viewer-bg-color: ' + backgroundColor }}"
     aria-role="button"
     aria-label="关闭"
   />

--- a/src/image-viewer/props.ts
+++ b/src/image-viewer/props.ts
@@ -9,7 +9,7 @@ const props: TdImageViewerProps = {
   /** 遮罩的背景颜色 */
   backgroundColor: {
     type: String,
-    value: 'rgba(0, 0, 0, 1)',
+    value: '',
   },
   /** 是否显示关闭操作，前提需要开启页码。值为字符串表示图标名称，值为 `true` 表示使用默认图标 `close`，值为 `Object` 类型，表示透传至 `icon` ，不传表示不显示图标 */
   closeBtn: {
@@ -31,7 +31,7 @@ const props: TdImageViewerProps = {
     type: Number,
     value: 0,
   },
-  /** 是否开启图片懒加载 */
+  /** 是否开启图片懒加载。开启后会预加载当前图片、相邻图片 */
   lazy: {
     type: Boolean,
     value: true,

--- a/src/image-viewer/type.ts
+++ b/src/image-viewer/type.ts
@@ -7,7 +7,7 @@
 export interface TdImageViewerProps {
   /**
    * 遮罩的背景颜色
-   * @default 'rgba(0, 0, 0, 1)'
+   * @default ''
    */
   backgroundColor?: {
     type: StringConstructor;
@@ -46,7 +46,7 @@ export interface TdImageViewerProps {
     value?: Number;
   };
   /**
-   * 是否开启图片懒加载
+   * 是否开启图片懒加载。开启后会预加载当前图片、相邻图片
    * @default true
    */
   lazy?: {

--- a/src/overlay/README.en-US.md
+++ b/src/overlay/README.en-US.md
@@ -26,5 +26,5 @@ click | `({ visible: boolean })` | \-
 The component provides the following CSS variables, which can be used to customize styles.
 Name | Default Value | Description 
 -- | -- | --
---td-overlay-bg-color | @font-gray-2 | - 
---td-overlay-transition-duration | 300ms | - 
+--td-overlay-bg-color | @mask-active | - 
+--td-overlay-transition-duration | 300ms | -

--- a/src/overlay/README.md
+++ b/src/overlay/README.md
@@ -62,5 +62,5 @@ click | `({ visible: boolean })` | 点击遮罩时触发
 组件提供了下列 CSS 变量，可用于自定义样式。
 名称 | 默认值 | 描述 
 -- | -- | --
---td-overlay-bg-color | @font-gray-2 | - 
---td-overlay-transition-duration | 300ms | - 
+--td-overlay-bg-color | @mask-active | - 
+--td-overlay-transition-duration | 300ms | -

--- a/src/overlay/overlay.less
+++ b/src/overlay/overlay.less
@@ -1,7 +1,7 @@
 @import '../common/style/base.less';
 
 @overlay: ~'@{prefix}-overlay';
-@overlay-bg-color: var(--td-overlay-bg-color, @font-gray-2);
+@overlay-bg-color: var(--td-overlay-bg-color, @mask-active);
 @overlay-transition-duration: var(--td-overlay-transition-duration, 300ms);
 
 .@{overlay} {

--- a/src/toast/README.en-US.md
+++ b/src/toast/README.en-US.md
@@ -37,9 +37,9 @@ t-class | \-
 The component provides the following CSS variables, which can be used to customize styles.
 Name | Default Value | Description 
 -- | -- | --
---td-toast-bg-color | @font-gray-2 | - 
+--td-toast-bg-color | @mask-active | - 
 --td-toast-color | @text-color-anti | - 
 --td-toast-column-icon-size | 64rpx | - 
 --td-toast-max-width | 374rpx | - 
 --td-toast-radius | 8rpx | - 
---td-toast-row-icon-size | 48rpx | - 
+--td-toast-row-icon-size | 48rpx | -

--- a/src/toast/README.md
+++ b/src/toast/README.md
@@ -74,9 +74,9 @@ t-class | 根节点样式类
 组件提供了下列 CSS 变量，可用于自定义样式。
 名称 | 默认值 | 描述 
 -- | -- | --
---td-toast-bg-color | @font-gray-2 | - 
+--td-toast-bg-color | @mask-active | - 
 --td-toast-color | @text-color-anti | - 
 --td-toast-column-icon-size | 64rpx | - 
 --td-toast-max-width | 374rpx | - 
 --td-toast-radius | 8rpx | - 
---td-toast-row-icon-size | 48rpx | - 
+--td-toast-row-icon-size | 48rpx | -

--- a/src/toast/toast.less
+++ b/src/toast/toast.less
@@ -1,7 +1,7 @@
 @import '../common/style/base.less';
 
 @toast-color: var(--td-toast-color, @text-color-anti);
-@toast-bg-color: var(--td-toast-bg-color, @font-gray-2);
+@toast-bg-color: var(--td-toast-bg-color, @mask-active);
 @toast-max-width: var(--td-toast-max-width, 374rpx);
 @toast-radius: var(--td-toast-radius, 8rpx);
 @toast-row-icon-size: var(--td-toast-row-icon-size, 48rpx);


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3842 

### 相关 PRs
https://github.com/TDesignOteam/tdesign-api/pull/694
https://github.com/Tencent/tdesign-common/pull/2245

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

解决方案：移除 backgroundColor 属性默认值，改用 design token。token 使用 @mask-active (已和设计同学确认✅）

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 移除 `backgroundColor` 属性默认值，导航背景色固定为 `#000`，遮罩背景色使用 `@mask-active`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
