### PR TITLE
fix(docs): 更正 overview 错误文案

### DIFF
--- a/site/docs/overview.md
+++ b/site/docs/overview.md
@@ -403,7 +403,7 @@ spline: explain
     <a class="item" href="/miniprogram/components/guide">
       <img class="__light__" src="https://tdesign.gtimg.com/site/mobile/doc-guide.png" />
       <img class="__dark__" src="https://tdesign.gtimg.com/site/mobile/doc-guide-dark.png" />
-      <p class="name">Guide 按钮</p>
+      <p class="name">Guide 引导</p>
     </a>
   </div>
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 文档改进

### 💡 需求背景和解决方案

将下图所示概览页的“Guide 按钮”更正为“Guide 引导”

<img width="1647" height="731" src="https://github.com/user-attachments/assets/c6f74688-b7f5-47d3-af54-a63dd964bce0" />

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充
- [x] 代码演示无须提供
- [x] TypeScript 定义无须补充
- [x] Changelog 无须提供
