### PR TITLE
fix(DateTimePicker): 修复在 showWeek 模式下日列表未正确排除 start、end、且 steps 步长不生效的 Bug

### DIFF
--- a/src/date-time-picker/date-time-picker.ts
+++ b/src/date-time-picker/date-time-picker.ts
@@ -101,25 +101,21 @@ export default class DateTimePicker extends SuperComponent {
       });
     },
 
-    getDaysOfWeekInMonth(date: Dayjs): Array<{ value: string; label: string }> {
-      const { locale, dayjsLocale } = this.data;
+    getDaysOfWeekInMonth(date: Dayjs, type: string): Array<{ value: string; label: string }> {
+      const { locale, steps, dayjsLocale } = this.data;
       const startOfMonth = date.startOf('month');
-      const endOfMonth = date.endOf('month');
-      const minDate = this.getMinDate();
-      const maxDate = this.getMaxDate();
+      const minEdge = this.getOptionEdge('min', type);
+      const maxEdge = this.getOptionEdge('max', type);
+      const step = steps?.[type] ?? 1;
       const daysOfWeek = [];
 
-      for (let i = 0; i <= endOfMonth.diff(startOfMonth, 'days'); i += 1) {
-        const currentDate = startOfMonth.add(i, 'days').locale(dayjsLocale);
-        if (currentDate.isBefore(minDate) || currentDate.isAfter(maxDate)) {
-          if (currentDate.isAfter(maxDate)) break;
-        } else {
-          const dayName = currentDate.format('ddd');
-          daysOfWeek.push({
-            value: `${i + 1}`,
-            label: `${i + 1}${locale.date || ''} ${dayName}`,
-          });
-        }
+      for (let i = minEdge; i <= maxEdge; i += step) {
+        const currentDate = startOfMonth.date(i).locale(dayjsLocale);
+        const dayName = currentDate.format('ddd');
+        daysOfWeek.push({
+          value: `${i}`,
+          label: `${i}${locale.date || ''} ${dayName}`,
+        });
       }
 
       return daysOfWeek;
@@ -222,7 +218,7 @@ export default class DateTimePicker extends SuperComponent {
       const dayjsMonthsShort = dayjs().locale(this.data.dayjsLocale).localeData().monthsShort();
 
       if (type === 'date' && showWeek) {
-        return this.getDaysOfWeekInMonth(this.date);
+        return this.getDaysOfWeekInMonth(this.date, type);
       }
 
       for (let i = minEdge; i <= maxEdge; i += step) {

--- a/src/date-time-picker/date-time-picker.ts
+++ b/src/date-time-picker/date-time-picker.ts
@@ -105,16 +105,21 @@ export default class DateTimePicker extends SuperComponent {
       const { locale, dayjsLocale } = this.data;
       const startOfMonth = date.startOf('month');
       const endOfMonth = date.endOf('month');
+      const minDate = this.getMinDate();
+      const maxDate = this.getMaxDate();
       const daysOfWeek = [];
 
       for (let i = 0; i <= endOfMonth.diff(startOfMonth, 'days'); i += 1) {
         const currentDate = startOfMonth.add(i, 'days').locale(dayjsLocale);
-        const dayName = currentDate.format('ddd');
-
-        daysOfWeek.push({
-          value: `${i + 1}`,
-          label: `${i + 1}${locale.date || ''} ${dayName}`,
-        });
+        if (currentDate.isBefore(minDate) || currentDate.isAfter(maxDate)) {
+          if (currentDate.isAfter(maxDate)) break;
+        } else {
+          const dayName = currentDate.format('ddd');
+          daysOfWeek.push({
+            value: `${i + 1}`,
+            label: `${i + 1}${locale.date || ''} ${dayName}`,
+          });
+        }
       }
 
       return daysOfWeek;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

fix #3860

当组件开启 `show-week` 且 `start="{{nowTime()}}"` 时，「日」列表界面与未开启 `show-week` 的「日」列表界面不一致：

1. 开启 `show-week` 时「日」列显示了 `nowTime()` 之前的日期，关闭 `show-week` 后则消失。
2. 开启 `show-week` 时，steps 步长设置对「日」不生效，关闭则正常。

### 💡 需求背景和解决方案

应该是在 `getOptionByType(type: string)` 函数中，`if (type === 'date' && showWeek)` 直接返回了 `getDaysOfWeekInMonth(this.date)` 的结果，忽视了 `start`、`end` 和 `steps` 值。

https://github.com/Tencent/tdesign-miniprogram/blob/b3bdc825a060f65fb61e48384ba54c7f666b220a/src/date-time-picker/date-time-picker.ts#L104-L121

我这里把上述函数代码改成以下代码就可以了：

```JavaScript
    getDaysOfWeekInMonth(date: Dayjs, type: string): Array<{ value: string; label: string }> {
      const { locale, steps, dayjsLocale } = this.data;
      const startOfMonth = date.startOf('month');
      const minEdge = this.getOptionEdge('min', type);
      const maxEdge = this.getOptionEdge('max', type);
      const step = steps?.[type] ?? 1;
      const daysOfWeek = [];

      for (let i = minEdge; i <= maxEdge; i += step) {
        const currentDate = startOfMonth.date(i).locale(dayjsLocale);
        const dayName = currentDate.format('ddd');
        daysOfWeek.push({
          value: `${i}`,
          label: `${i}${locale.date || ''} ${dayName}`,
        });
      }

      return daysOfWeek;
    },
```

### 📝 更新日志

- fix(DateTimePicker): 修复 `showWeek` 模式下日（`date`）列表未正确排除 `start` 和 `end`、且 `steps` 步长无效的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义无须补充
- [x] Changelog 已提供
