### PR TITLE
fix(steps): fix the spacing error between title and description

### DIFF
--- a/packages/components/step-item/step-item.less
+++ b/packages/components/step-item/step-item.less
@@ -79,6 +79,10 @@
     align-items: center;
   }
 
+  &--vertical {
+    margin-bottom: 16rpx;
+  }
+
   &__anchor {
     display: flex;
     align-items: center;
@@ -150,8 +154,11 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      margin-bottom: 8rpx;
     }
+  }
+
+  &__title + &__description:not(:empty) {
+    margin-top: 8rpx;
   }
 
   &__description {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 相关 PRs
https://github.com/Tencent/tdesign-common/pull/2269
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. title 和 description 间距为 4px
2. 子项之间间距 8px
<img width="436" height="146" alt="截屏2025-09-04 14 37 04" src="https://github.com/user-attachments/assets/7620091b-1eef-4fe9-80e4-09423a1c0d48" />

<img width="433" height="292" alt="截屏2025-09-04 14 37 15" src="https://github.com/user-attachments/assets/e027ae85-4b5e-4ffc-96ae-84f467470d66" />

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(StepItem): 修复 `title` 和 `description` 之间的间距错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
