### PR TITLE
feat(PickerItem): add icon prop

### DIFF
--- a/packages/components/picker-item/picker-item.json
+++ b/packages/components/picker-item/picker-item.json
@@ -1,5 +1,7 @@
 {
   "component": true,
   "styleIsolation": "apply-shared",
-  "usingComponents": {}
+  "usingComponents": {
+    "t-icon": "../icon/icon"
+  }
 }

--- a/packages/components/picker-item/picker-item.less
+++ b/packages/components/picker-item/picker-item.less
@@ -31,6 +31,11 @@
     color: @picker-item-color;
     font-size: @picker-item-font-size;
 
+    &-icon {
+      font-size: 36rpx;
+      margin-right: @spacer;
+    }
+
     &-label {
       white-space: nowrap;
       text-overflow: ellipsis;

--- a/packages/components/picker-item/picker-item.ts
+++ b/packages/components/picker-item/picker-item.ts
@@ -39,7 +39,7 @@ export default class PickerItem extends SuperComponent {
           if (keys === null || JSON.stringify(this.data.pickerKeys) === JSON.stringify(keys)) return;
 
           this.setData({
-            pickerKeys: keys,
+            pickerKeys: { ...this.data.pickerKeys, ...keys },
           });
         }
       },
@@ -68,7 +68,7 @@ export default class PickerItem extends SuperComponent {
     value: '',
     curIndex: 0,
     columnIndex: 0,
-    pickerKeys: { value: 'value', label: 'label' },
+    pickerKeys: { value: 'value', label: 'label', icon: 'icon' },
     formatOptions: props.options.value,
   };
 

--- a/packages/components/picker-item/picker-item.wxml
+++ b/packages/components/picker-item/picker-item.wxml
@@ -16,7 +16,7 @@
       class="{{_.cls(classPrefix + '__item', [['active', curIndex == index]])}}"
       style="height: {{pickItemHeight}}px"
       wx:for="{{formatOptions}}"
-      wx:key="index"
+      wx:key="value"
       wx:for-item="option"
       data-index="{{ index }}"
       bind:tap="onClickItem"

--- a/packages/components/picker-item/picker-item.wxml
+++ b/packages/components/picker-item/picker-item.wxml
@@ -21,6 +21,11 @@
       data-index="{{ index }}"
       bind:tap="onClickItem"
     >
+      <t-icon
+        wx:if="{{option[pickerKeys.icon]}}"
+        class="{{classPrefix}}__item-icon"
+        name="{{option[pickerKeys.icon]}}"
+      />
       <text class="{{classPrefix}}__item-label">{{option[pickerKeys.label]}}</text>
       <slot name="label-suffix--{{index}}"></slot>
     </view>

--- a/packages/components/picker-item/type.ts
+++ b/packages/components/picker-item/type.ts
@@ -25,4 +25,5 @@ export interface TdPickerItemProps {
 export interface PickerItemOption {
   label: string;
   value: string | number;
+  icon?: string;
 }

--- a/packages/components/picker/README.en-US.md
+++ b/packages/components/picker/README.en-US.md
@@ -41,7 +41,7 @@ name | type | default | description | required
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
 format | Function | - | Typescript：`(option: PickerItemOption, columnIndex: number) => PickerItemOption` | N
-options | Array | [] | Typescript：`PickerItemOption[]` `interface PickerItemOption { label: string; value: string \| number }`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/picker-item/type.ts) | N
+options | Array | [] | Typescript：`PickerItemOption[]` `interface PickerItemOption { label: string; value: string \| number; icon?: string }`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/picker-item/type.ts) | N
 
 ### CSS Variables
 

--- a/packages/components/picker/README.md
+++ b/packages/components/picker/README.md
@@ -59,7 +59,7 @@ confirm-btn | String / Boolean | true | 确定按钮文字。TS 类型：`boolea
 footer | Slot | - | 底部内容。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
 header | Boolean / Slot | true | 头部内容。值为 true 显示空白头部，值为 false 不显示任何内容。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
 item-height | Number | 80 | PickerItem 的子项高度，单位 rpx | N
-keys | Object | - | 用来定义 value / label 在 `options` 中对应的字段别名。TS 类型：`KeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
+keys | Object | - | 用来定义 value / label / icon 在 `options` 中对应的字段别名。TS 类型：`KeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
 popup-props | Object | {} | 透传 Popup 组件全部属性。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/picker/type.ts) | N
 title | String | '' | 标题 | N
 use-popup | Boolean | true | 是否使用弹出层包裹 | N
@@ -86,7 +86,7 @@ pick | `(value: Array<PickerValue>, label: string, column: number, index: number
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
 format | Function | - | 格式化标签。TS 类型：`(option: PickerItemOption, columnIndex: number) => PickerItemOption` | N
-options | Array | [] | 数据源。TS 类型：`PickerItemOption[]` `interface PickerItemOption { label: string; value: string \| number }`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/picker-item/type.ts) | N
+options | Array | [] | 数据源。TS 类型：`PickerItemOption[]` `interface PickerItemOption { label: string; value: string \| number; icon?: string }`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/picker-item/type.ts) | N
 
 ### CSS Variables
 

--- a/packages/components/picker/__test__/__snapshots__/demo.test.js.snap
+++ b/packages/components/picker/__test__/__snapshots__/demo.test.js.snap
@@ -153,6 +153,7 @@ exports[`Picker Picker base demo works fine 1`] = `
       options="{{
         Array [
           Object {
+            "icon": "home",
             "label": "北京市",
             "tag": "合",
             "value": "北京市",

--- a/packages/components/picker/_example/base/index.js
+++ b/packages/components/picker/_example/base/index.js
@@ -5,7 +5,7 @@ Component({
     dateText: '',
     dateValue: [],
     citys: [
-      { label: '北京市', value: '北京市', tag: '合' },
+      { label: '北京市', value: '北京市', icon: 'home', tag: '合' },
       { label: '上海市', value: '上海市', tag: '合' },
       { label: '广州市', value: '广州市' },
       { label: '深圳市', value: '深圳市' },
@@ -26,6 +26,7 @@ Component({
       const { value, label } = item;
       if (value === '北京市') {
         return {
+          ...item,
           value,
           label: label.substring(0, 2),
         };

--- a/packages/components/picker/props.ts
+++ b/packages/components/picker/props.ts
@@ -31,7 +31,7 @@ const props: TdPickerProps = {
     type: Number,
     value: 80,
   },
-  /** 用来定义 value / label 在 `options` 中对应的字段别名 */
+  /** 用来定义 value / label / icon 在 `options` 中对应的字段别名 */
   keys: {
     type: Object,
   },

--- a/packages/components/picker/type.ts
+++ b/packages/components/picker/type.ts
@@ -49,7 +49,7 @@ export interface TdPickerProps {
     value?: number;
   };
   /**
-   * 用来定义 value / label 在 `options` 中对应的字段别名
+   * 用来定义 value / label / icon 在 `options` 中对应的字段别名
    */
   keys?: {
     type: ObjectConstructor;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #3891

### 相关 PRs
https://github.com/TDesignOteam/tdesign-api/pull/717

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
其他：

问题： skyline 下出现，key 不唯一带来的控制台告警。

原因/方案：wx:key="index“ 的设置并不能确保在数据列表改变时触发渲染层重新排序， wx:key 必须具备唯一性。本次将 wx:key 调整为 value，只能解决列表中存在 value 字段且唯一的场景出现的控制台告警，一旦传入的列表没有 value 字段，也会出现控制台告警。ActionSheet 、Cascader 等支持传入列表项的组件应该都有该类问题，或者这里需要重新制定规则，补充 id 属性（必须），并将 id 作为唯一键使用⚠️

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(PickerItem):  子项支持 `icon` 属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
