### PR TITLE
feat(Calendar): support allowSameDay prop

### DIFF
--- a/packages/components/calendar/README.en-US.md
+++ b/packages/components/calendar/README.en-US.md
@@ -8,21 +8,22 @@ name | type | default | description | required
 -- | -- | -- | -- | --
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
+allow-same-day | Boolean | false | `1.11.2` | N
 auto-close | Boolean | true | `0.34.0` | N
 confirm-btn | String / Object | '' | [see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
 first-day-of-week | Number | 0 | \- | N
-format | Function | - | Typescript：`CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
-locale-text | Object | - | Typescript：`CalendarLocaleText` `interface CalendarLocaleText {title?: string; weekdays?: string[]; monthTitle?: string; months?: string[]; confirm?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
+format | Function | - | Typescript: `CalendarFormatType ` `type CalendarFormatType = (day: TDate) => TDate` `type TDateType = 'selected' \| 'disabled' \| 'start' \| 'centre' \| 'end' \| ''` `interface TDate { date: Date; day: number; type: TDateType; className?: string; prefix?: string; suffix?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
+locale-text | Object | - | Typescript: `CalendarLocaleText` `interface CalendarLocaleText {title?: string; weekdays?: string[]; monthTitle?: string; months?: string[]; confirm?: string;}`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
 max-date | Number | - | \- | N
 min-date | Number | - | \- | N
 readonly | Boolean | - | `1.9.7` | N
 switch-mode | String | none | `1.8.2`。options: none/month/year-month | N
 title | String | - | \- | N
-type | String | 'single' | options: single/multiple/range | N
+type | String | single | options: single/multiple/range | N
 use-popup | Boolean | true | `0.32.0` | N
 using-custom-navbar | Boolean | false | \- | N
-value | Number / Array | - | Typescript：`number \| number[]` | N
-default-value | Number / Array | undefined | uncontrolled property。Typescript：`number \| number[]` | N
+value | Number / Array | - | Typescript: `number \| number[]` | N
+default-value | Number / Array | undefined | uncontrolled property。Typescript: `number \| number[]` | N
 visible | Boolean | false | \- | N
 
 ### Calendar Events

--- a/packages/components/calendar/README.md
+++ b/packages/components/calendar/README.md
@@ -74,6 +74,7 @@ isComponent: true
 -- | -- | -- | -- | --
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
+allow-same-day | Boolean | false | `1.11.2`。是否允许区间选择日历的起止时间相同，仅当 `type='range'` 时有效 | N
 auto-close | Boolean | true | `0.34.0`。自动关闭；在点击关闭按钮、确认按钮、遮罩层时自动关闭，不需要手动设置 visible | N
 confirm-btn | String / Object | '' | 确认按钮。值为 null 则不显示确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/calendar/type.ts) | N
 first-day-of-week | Number | 0 | 第一天从星期几开始，默认 0 = 周日 | N
@@ -84,7 +85,7 @@ min-date | Number | - | 最小可选的日期，不传则默认今天 | N
 readonly | Boolean | - | `1.9.7`。是否只读，只读状态下不能选择日期 | N
 switch-mode | String | none | `1.8.2`。切换模式。 `none` 表示平铺展示所有月份； `month` 表示支持按月切换， `year-month` 表示既按年切换，也支持按月切换。可选项：none/month/year-month | N
 title | String | - | 标题，不传默认为“请选择日期” | N
-type | String | 'single' | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
+type | String | single | 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择。可选项：single/multiple/range | N
 use-popup | Boolean | true | `0.32.0`。是否使用弹出层包裹日历 | N
 using-custom-navbar | Boolean | false | 是否使用了自定义导航栏 | N
 value | Number / Array | - | 当前选择的日期，不传则选用 minDate 属性值或今天，优先级：minDate > today。当 type = multiple 或 range 时传入数组。TS 类型：`number \| number[]` | N

--- a/packages/components/calendar/calendar.less
+++ b/packages/components/calendar/calendar.less
@@ -139,6 +139,7 @@
       }
 
       &--selected,
+      &--start-end,
       &--start,
       &--end {
         background: @calendar-active-color;

--- a/packages/components/calendar/calendar.ts
+++ b/packages/components/calendar/calendar.ts
@@ -86,6 +86,10 @@ export default class Calendar extends SuperComponent {
       this.base.type = v;
     },
 
+    allowSameDay(v) {
+      this.base.allowSameDay = v;
+    },
+
     confirmBtn(v) {
       if (typeof v === 'string') {
         this.setData({ innerConfirmBtn: v === 'slot' ? 'slot' : { content: v } });

--- a/packages/components/calendar/props.ts
+++ b/packages/components/calendar/props.ts
@@ -6,6 +6,11 @@
 
 import { TdCalendarProps } from './type';
 const props: TdCalendarProps = {
+  /** 是否允许区间选择日历的起止时间相同，仅当 `type='range'` 时有效 */
+  allowSameDay: {
+    type: Boolean,
+    value: false,
+  },
   /** 自动关闭；在点击关闭按钮、确认按钮、遮罩层时自动关闭，不需要手动设置 visible */
   autoClose: {
     type: Boolean,

--- a/packages/components/calendar/type.ts
+++ b/packages/components/calendar/type.ts
@@ -8,6 +8,14 @@ import { ButtonProps } from '../button/index';
 
 export interface TdCalendarProps {
   /**
+   * 是否允许区间选择日历的起止时间相同，仅当 `type='range'` 时有效
+   * @default false
+   */
+  allowSameDay?: {
+    type: BooleanConstructor;
+    value?: boolean;
+  };
+  /**
    * 自动关闭；在点击关闭按钮、确认按钮、遮罩层时自动关闭，不需要手动设置 visible
    * @default true
    */
@@ -83,7 +91,7 @@ export interface TdCalendarProps {
   };
   /**
    * 日历的选择类型，single = 单选；multiple = 多选; range = 区间选择
-   * @default 'single'
+   * @default single
    */
   type?: {
     type: StringConstructor;

--- a/packages/components/common/shared/calendar/index.ts
+++ b/packages/components/common/shared/calendar/index.ts
@@ -12,6 +12,8 @@ export default class TCalendar {
 
   maxDate: Date;
 
+  allowSameDay: Boolean;
+
   format: (day: TDate) => TDate;
 
   constructor(options = {}) {
@@ -54,7 +56,7 @@ export default class TCalendar {
   getMonths() {
     const ans = [];
     const selectedDate = this.getTrimValue();
-    const { minDate, maxDate, type, format } = this;
+    const { minDate, maxDate, type, allowSameDay, format } = this;
     const minDateRect = getDateRect(minDate);
     let { year: minYear, month: minMonth } = minDateRect;
     const { time: minTime } = minDateRect;
@@ -74,9 +76,12 @@ export default class TCalendar {
       if (type === 'range' && selectedDate) {
         if (Array.isArray(selectedDate)) {
           const [startDate, endDate] = selectedDate;
+          const compareWithStart = startDate && isSameDate({ year, month, date }, startDate);
+          const compareWithEnd = endDate && isSameDate({ year, month, date }, endDate);
 
-          if (startDate && isSameDate({ year, month, date }, startDate)) return 'start';
-          if (endDate && isSameDate({ year, month, date }, endDate)) return 'end';
+          if (compareWithStart && compareWithEnd && allowSameDay) return 'start-end';
+          if (compareWithStart) return 'start';
+          if (compareWithEnd) return 'end';
           if (startDate && endDate && curDate.getTime() > startDate.getTime() && curDate.getTime() < endDate.getTime())
             return 'centre';
         }
@@ -124,7 +129,7 @@ export default class TCalendar {
     this.value = selected;
 
     if (type === 'range' && Array.isArray(selectedDate)) {
-      if (selectedDate.length === 1 && selected > selectedDate[0]) {
+      if (selectedDate.length === 1 && selected >= selectedDate[0]) {
         this.value = [selectedDate[0], selected];
       } else {
         this.value = [selected];

--- a/packages/components/common/shared/calendar/type.ts
+++ b/packages/components/common/shared/calendar/type.ts
@@ -1,6 +1,6 @@
 export type TCalendarValue = number | Date;
 
-export type TDateType = 'selected' | 'disabled' | 'start' | 'centre' | 'end' | '';
+export type TDateType = 'selected' | 'disabled' | 'start-end' | 'start' | 'centre' | 'end' | '';
 
 export type TCalendarType = 'single' | 'multiple' | 'range';
 

--- a/packages/components/common/shared/date.ts
+++ b/packages/components/common/shared/date.ts
@@ -12,7 +12,7 @@ export const getDateRect = (date: Date | number) => {
   };
 };
 
-export const isSameDate = (date1: CompareDate, date2: CompareDate) => {
+export const isSameDate = (date1: CompareDate, date2: CompareDate): Boolean => {
   if (date1 instanceof Date || typeof date1 === 'number') date1 = getDateRect(date1);
   if (date2 instanceof Date || typeof date2 === 'number') date2 = getDateRect(date2);
   const keys = ['year', 'month', 'date'];


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #4037 

### 相关PRs
https://github.com/TDesignOteam/tdesign-api/pull/767
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Calendar): 新增 `allowSameDay` 属性，允许 `type='range'` 场景的起始时间相同

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
