### PR TITLE
fix(Toast): ensure the close callback is reset to the passed-in value or null.

### DIFF
--- a/packages/components/toast/toast.ts
+++ b/packages/components/toast/toast.ts
@@ -61,6 +61,7 @@ export default class Toast extends SuperComponent {
         placement: props.placement.value,
         preventScrollThrough: props.preventScrollThrough.value,
         theme: props.theme.value,
+        close: null, // 确保 close 回调被重置为当前传入的值或 null
       };
 
       const data = {


### PR DESCRIPTION

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #4097
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Toast): 修复 `Toast` 嵌套调用时 `close` 回调陷入循环的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
