### PR TITLE
fix(attachments): 修复附件关闭icon在不同机型的显示（#4121）

### DIFF
--- a/packages/pro-components/chat/attachments/attachments.less
+++ b/packages/pro-components/chat/attachments/attachments.less
@@ -4,7 +4,7 @@
 
 @attachments-background-color: @bg-color-secondarycontainer;
 @attachments-file-margin: 16rpx;
-@attachments-file-margin-tiny: 8rpx;
+@attachments-file-margin-tiny: 10rpx;
 @attachments-file-padding: 24rpx;
 @attachments-file-image-size: 104rpx;
 @attachments-file-width: 256rpx;
@@ -92,10 +92,12 @@
     display: block;
     position: relative;
     background-color: @attachments-background-color;
+    overflow: visible; // 允许删除按钮溢出显示
 
-    // 仅当有删除按钮时，增加上边距
+    // 仅当有删除按钮时，增加上边距和右边距以留出删除按钮空间
     &--removable {
-      margin-top: @attachments-file-margin-tiny;
+      margin-top: 12rpx;
+      margin-right: 8rpx;
     }
 
     // 删除按钮样式
@@ -104,8 +106,8 @@
       color: @bg-color-container;
       border-radius: @radius-circle;
       position: absolute;
-      right: -4px;
-      top: -4px;
+      right: -8rpx;
+      top: -8rpx;
     }
 
     // 图片文件样式 适配图片附件在聊天中的特殊样式
@@ -183,7 +185,6 @@
 
 // 对话中附件样式覆盖
 .@{attachments}--chatting {
-
   &.all_images {
     width: 100%;
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #4121

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Attachments): 修复删除按钮在华为 `pure70` 机型上显示不完整的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
