### PR TITLE
fix(slider): 修复受控模式下陷入死循环问题

### DIFF
--- a/packages/components/slider/slider.ts
+++ b/packages/components/slider/slider.ts
@@ -216,8 +216,10 @@ export default class Slider extends SuperComponent {
     const value = trimValue(newValue, this.properties);
     const realLabel = this.getLabelByValue(value);
 
-    // 不触发 change 事件，避免受控模式下死循环
-    this.preval = value;
+    // 避免受控模式下死循环，同时不影响初始化后的首次点击
+    if (this.preval !== undefined) {
+      this.preval = value;
+    }
 
     const setValueAndTrigger = () => {
       this.setData({


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #4164 

### 💡 需求背景和解决方案
需求背景：​ 受控 + 双游标滑块场景出现死循环。
解决方案：1、数组引用比较失效，需要使用JSON.stringify；2、value observer 中不要触发change事件。


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Slider): 修复受控 + 双游标滑块模式下陷入死循环的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
