### PR TITLE
feat(SideBarItem): improve the display logic for prefix and suffix elements of activated items

### DIFF
--- a/packages/components/side-bar-item/side-bar-item.wxml
+++ b/packages/components/side-bar-item/side-bar-item.wxml
@@ -14,8 +14,8 @@
 >
   <block wx:if="{{active}}">
     <view class="{{classPrefix}}__line"></view>
-    <view class="{{classPrefix}}__prefix"></view>
-    <view class="{{classPrefix}}__suffix"></view>
+    <view wx:if="{{!isFirstChild}}" class="{{classPrefix}}__prefix"></view>
+    <view wx:if="{{!isLastChild}}" class="{{classPrefix}}__suffix"></view>
   </block>
   <template wx:if="{{_icon}}" is="icon" data="{{ tClass: classPrefix + '__icon', ..._icon }}" />
   <block wx:if="{{badgeProps}}">

--- a/packages/components/side-bar/side-bar.ts
+++ b/packages/components/side-bar/side-bar.ts
@@ -4,7 +4,6 @@ import props from './props';
 
 const { prefix } = config;
 const name = `${prefix}-side-bar`;
-const relationsPath = '../side-bar-item/side-bar-item';
 
 @wxComponent()
 export default class SideBar extends SuperComponent {
@@ -13,7 +12,7 @@ export default class SideBar extends SuperComponent {
   children = [];
 
   relations: RelationsOptions = {
-    [relationsPath]: {
+    '../side-bar-item/side-bar-item': {
       type: 'child',
       linked(child) {
         this.children.push(child);
@@ -36,8 +35,13 @@ export default class SideBar extends SuperComponent {
 
   observers = {
     value(v) {
-      this.$children.forEach((item) => {
+      const sideBarItems = this.$children;
+      sideBarItems.forEach((item, index) => {
         item.updateActive(v);
+        item.setData({
+          isFirstChild: index === 0,
+          isLastChild: index === sideBarItems.length - 1,
+        });
       });
     },
   };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #4163 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(SideBarItem): 完善激活项的前缀和后缀元素显示逻辑

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
