### PR TITLE
chore(Form): reuse the logic from the H5 client

### DIFF
--- a/packages/components/common/validator.ts
+++ b/packages/components/common/validator.ts
@@ -40,3 +40,213 @@ export function isObject(x: unknown): x is Record<string, unknown> {
 export function isPlainObject(val: unknown): val is Record<string, unknown> {
   return val !== null && typeof val === 'object' && Object.prototype.toString.call(val) === '[object Object]';
 }
+
+export function isEmpty(val: unknown): boolean {
+  if (val === null || val === undefined) return true;
+  if (typeof val === 'string' || Array.isArray(val)) return val.length === 0;
+  if (val instanceof Map || val instanceof Set) return val.size === 0;
+  if (typeof val === 'object') return Object.keys(val as Record<string, unknown>).length === 0;
+  return true;
+}
+
+/**
+ * 验证是否为有效日期
+ * 参考 validator.js 的 isDate 实现
+ * 支持字符串格式（YYYY/MM/DD、YYYY-MM-DD 等）和 Date 对象
+ */
+export function isDate(
+  input: unknown,
+  options?: { format?: string; delimiters?: string[]; strictMode?: boolean },
+): boolean {
+  const defaultOptions = {
+    format: 'YYYY/MM/DD',
+    delimiters: ['/', '-'],
+    strictMode: false,
+  };
+  const opts = { ...defaultOptions, ...options };
+
+  if (typeof input === 'string') {
+    // 确定分隔符
+    const delimiter = opts.delimiters.find((d) => opts.format.includes(d));
+    if (!delimiter) return false;
+
+    const formatParts = opts.format.split(delimiter);
+    const dateParts = input.split(delimiter);
+    if (formatParts.length !== dateParts.length) return false;
+
+    let year = '';
+    let month = '';
+    let day = '';
+    for (let i = 0; i < formatParts.length; i += 1) {
+      const fmt = formatParts[i].toUpperCase();
+      const val = dateParts[i];
+      if (fmt.includes('Y')) year = val;
+      else if (fmt.includes('M')) month = val;
+      else if (fmt.includes('D')) day = val;
+    }
+
+    // 补零
+    if (month.length === 1) month = `0${month}`;
+    if (day.length === 1) day = `0${day}`;
+
+    // 两位年份转四位
+    if (year.length === 2) {
+      const currentYearSuffix = new Date().getFullYear() % 100;
+      year = Number(year) <= currentYearSuffix ? `20${year}` : `19${year}`;
+    }
+
+    const date = new Date(`${year}-${month}-${day}T00:00:00.000Z`);
+    return (
+      date.getUTCFullYear() === Number(year) &&
+      date.getUTCMonth() + 1 === Number(month) &&
+      date.getUTCDate() === Number(day)
+    );
+  }
+
+  if (!opts.strictMode) {
+    if (Object.prototype.toString.call(input) === '[object Date]' && Number.isFinite((input as Date).getTime())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * 验证是否为有效邮箱地址
+ * 参考 validator.js 的 isEmail 实现
+ */
+export function isEmail(str: unknown): boolean {
+  if (typeof str !== 'string') return false;
+
+  // 邮箱最大长度 254
+  if (str.length > 254) return false;
+
+  const parts = str.split('@');
+  if (parts.length !== 2) return false;
+
+  const [user, domain] = parts;
+
+  // 本地部分最长 64 字节
+  if (!user || user.length > 64) return false;
+  // 域名部分不能为空
+  if (!domain) return false;
+
+  // 域名不能以 - 或 . 开头/结尾
+  if (/^[-.]/.test(domain) || /[-.]$/.test(domain)) return false;
+  // 域名格式校验：允许字母、数字、连字符、点
+  if (!/^[a-zA-Z0-9.-]+$/.test(domain)) return false;
+  // 域名至少有一个点（需要顶级域名）
+  if (!domain.includes('.')) return false;
+  // 顶级域名至少两个字符
+  const tld = domain.split('.').pop();
+  if (!tld || tld.length < 2) return false;
+
+  // 本地部分允许字母、数字和 .!#$%&'*+/=?^_`{|}~-
+  const emailUserReg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+$/;
+  return emailUserReg.test(user);
+}
+
+/**
+ * 验证是否为有效 URL
+ * 参考 validator.js 的 isURL 实现
+ */
+export function isURL(
+  str: unknown,
+  options?: {
+    protocols?: string[];
+    require_tld?: boolean;
+    require_protocol?: boolean;
+    require_host?: boolean;
+    allow_protocol_relative_urls?: boolean;
+  },
+): boolean {
+  if (typeof str !== 'string') return false;
+  if (str.length === 0 || /\s/.test(str)) return false;
+  // 最大长度限制
+  if (str.length > 2084) return false;
+
+  const defaultOpts = {
+    protocols: ['http', 'https', 'ftp'],
+    require_tld: true,
+    require_protocol: false,
+    require_host: true,
+    allow_protocol_relative_urls: false,
+  };
+  const opts = { ...defaultOpts, ...options };
+
+  let url = str;
+
+  // 检查协议
+  const protocolRegex = /^([a-z][a-z0-9+\-.]*):\/\//i;
+  const protocolMatch = url.match(protocolRegex);
+  if (protocolMatch) {
+    const protocol = protocolMatch[1].toLowerCase();
+    if (!opts.protocols.includes(protocol)) return false;
+    url = url.slice(protocolMatch[0].length);
+  } else if (opts.require_protocol) {
+    // 协议相对 URL
+    if (opts.allow_protocol_relative_urls && str.startsWith('//')) {
+      url = url.slice(2);
+    } else {
+      return false;
+    }
+  } else if (str.startsWith('//')) {
+    if (!opts.allow_protocol_relative_urls) return false;
+    url = url.slice(2);
+  }
+
+  if (!url && opts.require_host) return false;
+
+  // 分离路径、查询、片段
+  const [hostPart] = url.split(/[/?#]/);
+  if (!hostPart && opts.require_host) return false;
+
+  // 分离认证信息
+  let host = hostPart;
+  if (host.includes('@')) {
+    host = host.split('@').pop() || '';
+  }
+
+  // 分离端口
+  let hostname = host;
+  const portMatch = host.match(/:(\d+)$/);
+  if (portMatch) {
+    const port = Number(portMatch[1]);
+    if (port < 0 || port > 65535) return false;
+    hostname = host.slice(0, host.lastIndexOf(':'));
+  }
+
+  if (!hostname) return false;
+
+  // 检查是否为 IP 地址
+  const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+  const ipv4Match = hostname.match(ipv4Regex);
+  if (ipv4Match) {
+    return ipv4Match.slice(1).every((part) => Number(part) >= 0 && Number(part) <= 255);
+  }
+
+  // IPv6 简单检查
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return true;
+  }
+
+  // FQDN 检查
+  const domainParts = hostname.split('.');
+  if (opts.require_tld && domainParts.length < 2) return false;
+  // 每段不能为空，且只能包含字母、数字、连字符
+  const hasInvalidPart = domainParts.some((part) => {
+    if (!part || part.length > 63) return true;
+    if (!/^[a-zA-Z0-9-]+$/.test(part)) return true;
+    if (part.startsWith('-') || part.endsWith('-')) return true;
+    return false;
+  });
+  if (hasInvalidPart) return false;
+  // TLD 不能全是数字
+  if (opts.require_tld) {
+    const tld = domainParts[domainParts.length - 1];
+    if (/^\d+$/.test(tld)) return false;
+  }
+
+  return true;
+}

--- a/packages/components/form-item/form-item.ts
+++ b/packages/components/form-item/form-item.ts
@@ -1,5 +1,5 @@
 import props from './props';
-import { validateRules, ValidateStatus, RULE_KEYS } from './form-model';
+import { validateRules, ValidateStatus } from './form-model';
 import config from '../common/config';
 import { SuperComponent, wxComponent, RelationsOptions } from '../common/src/index';
 import usingConfig from '../mixins/using-config';
@@ -196,16 +196,14 @@ export default class FormItem extends SuperComponent {
         .map((item) => {
           if (item.message) return item;
 
-          for (let i = 0; i < RULE_KEYS.length; i += 1) {
-            const key = RULE_KEYS[i];
-            if (item[key] !== undefined && errorMessage[key]) {
+          Object.keys(item).forEach((key) => {
+            if (!item.message && errorMessage[key]) {
               const template = errorMessage[key];
               item.message = template
                 .replace(/\$\{name\}/g, labelName || '')
                 .replace(/\$\{validate\}/g, String(item[key] === true ? '' : item[key]));
-              break;
             }
-          }
+          });
           return item;
         });
 

--- a/packages/components/form-item/form-model.ts
+++ b/packages/components/form-item/form-model.ts
@@ -1,9 +1,13 @@
-interface ValidateResult {
-  result: boolean;
-  message?: string;
-  type?: string;
-  [key: string]: any;
-}
+import { isNumber, isBoolean, isObject, isEmpty, isDate, isEmail, isURL } from '../common/validator';
+import {
+  CustomValidator,
+  ValueType,
+  FormRule,
+  AllValidateResult,
+  CustomValidateResolveType,
+  ValidateResultType,
+  Data,
+} from '../form/type';
 
 export const ValidateStatus = {
   TO_BE_VALIDATED: 0,
@@ -11,104 +15,149 @@ export const ValidateStatus = {
   FAIL: 2,
 };
 
-export function isEmpty(value: any): boolean {
-  if (value === undefined || value === null || value === '') return true;
-  if (Array.isArray(value) && value.length === 0) return true;
-  return false;
-}
-
-export function getRuleValue(field: any): any {
-  if (field && typeof field === 'object' && 'value' in field) {
-    return field.value;
+/**
+ * 计算字符串字符的长度并可以截取字符串。
+ * @param str 传入字符串
+ * @param maxCharacter 规定最大字符串长度
+ * @returns 当没有传入maxCharacter时返回字符串字符长度，当传入maxCharacter时返回截取之后的字符串和长度。
+ */
+function getCharacterLength(str: string, maxCharacter?: number) {
+  const hasMaxCharacter = isNumber(maxCharacter);
+  if (!str || str.length === 0) {
+    if (hasMaxCharacter) {
+      return {
+        length: 0,
+        characters: str,
+      };
+    }
+    return 0;
   }
-  return field;
-}
-
-export function getResultType(rule: any): string {
-  const t = rule.type;
-  if (t === 'warning') return 'warning';
-  if (t && typeof t === 'object' && 'value' in t && t.value === 'warning') return 'warning';
-  return 'error';
-}
-
-function fail(rule: any, resultType: string): ValidateResult {
-  return { ...rule, result: false, message: getRuleValue(rule.message) || '', type: resultType };
-}
-
-export function getCharLength(str: string): number {
-  let length = 0;
+  let len = 0;
   for (let i = 0; i < str.length; i += 1) {
-    const code = str.charCodeAt(i);
-    const isCJK =
-      (code >= 0x4e00 && code <= 0x9fff) ||
-      (code >= 0x3400 && code <= 0x4dbf) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xff00 && code <= 0xffef);
-    length += isCJK ? 2 : 1;
+    let currentStringLength = 0;
+    if (str.charCodeAt(i) > 127 || str.charCodeAt(i) === 94) {
+      currentStringLength = 2;
+    } else {
+      currentStringLength = 1;
+    }
+    if (hasMaxCharacter && len + currentStringLength > maxCharacter) {
+      return {
+        length: len,
+        characters: str.slice(0, i),
+      };
+    }
+    len += currentStringLength;
   }
-  return length;
+  if (hasMaxCharacter) {
+    return {
+      length: len,
+      characters: str,
+    };
+  }
+  return len;
 }
 
-function getComparableLength(value: any): number {
-  if (typeof value === 'number') return value;
-  if (Array.isArray(value)) return value.length;
-  return getCharLength(String(value));
+// `{} / [] / '' / undefined / null` 等内容被认为是空； 0 和 false 被认为是正常数据，部分数据的值就是 0 或者 false
+export function isValueEmpty(val: any): boolean {
+  const type: string = Object.prototype.toString.call(val);
+  const typeMap: Record<string, any> = {
+    Date: '[object Date]',
+  };
+  if (type === typeMap.Date) {
+    return false;
+  }
+  return isObject(val) ? isEmpty(val) : ['', undefined, null].includes(val);
 }
 
-function toRegExp(pattern: any): RegExp | null {
-  if (pattern instanceof RegExp) return pattern;
-  if (typeof pattern === 'string') return new RegExp(pattern);
-  if (pattern && typeof pattern === 'object' && 'test' in pattern) return pattern;
-  return null;
-}
-
-type ValidateFn = (value: any, ruleValue: any) => boolean;
-
-const VALIDATE_MAP: Record<string, ValidateFn> = {
-  required: (value) => !isEmpty(value),
-  whitespace: (value) => !(typeof value === 'string' && value.trim() === ''),
-  boolean: (value) => typeof value === 'boolean',
-  number: (value) => !Number.isNaN(Number(value)),
-  email: (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value)),
-  url: (value) => /^https?:\/\/[^\s]+$/.test(String(value)),
-  date: (value) => !Number.isNaN(new Date(value).getTime()),
-  idcard: (value) => /^(\d{18}|\d{15}|\d{17}[xX])$/.test(String(value)),
-  telnumber: (value) => /^1[3-9]\d{9}$/.test(String(value)),
-  enum: (value, list) => !Array.isArray(list) || list.includes(value),
-  min: (value, limit) => getComparableLength(value) >= Number(limit),
-  max: (value, limit) => getComparableLength(value) <= Number(limit),
-  len: (value, length) => getCharLength(String(value)) === Number(length),
-  pattern: (value, pat) => {
-    const regex = toRegExp(pat);
-    return regex ? regex.test(String(value)) : false;
+const VALIDATE_MAP = {
+  date: isDate,
+  url: isURL,
+  email: isEmail,
+  required: (val: ValueType): boolean => !isValueEmpty(val),
+  whitespace: (val: ValueType): boolean => !(/^\s+$/.test(val) || val === ''),
+  boolean: (val: ValueType): boolean => isBoolean(val),
+  max: (val: ValueType, num: number): boolean =>
+    isNumber(val) ? val <= num : (getCharacterLength(val) as number) <= num,
+  min: (val: ValueType, num: number): boolean =>
+    isNumber(val) ? val >= num : (getCharacterLength(val) as number) >= num,
+  len: (val: ValueType, num: number): boolean => getCharacterLength(val) === num,
+  number: (val: ValueType): boolean => isNumber(val),
+  enum: (val: ValueType, strs: Array<string>): boolean => strs.includes(val),
+  idcard: (val: ValueType): boolean => /^(\d{18,18}|\d{15,15}|\d{17,17}x)$/i.test(val),
+  telnumber: (val: ValueType): boolean => /^1[3-9]\d{9}$/.test(val),
+  pattern: (val: ValueType, regexp: RegExp | string): boolean => {
+    const reg = typeof regexp === 'string' ? new RegExp(regexp) : regexp;
+    return reg.test(val);
   },
+  // 自定义校验规则，可能是异步校验
+  validator: (
+    val: ValueType,
+    validate: CustomValidator,
+    context?: { formData: Data; name: string },
+  ): ReturnType<CustomValidator> => validate(val, context),
 };
 
-export const RULE_KEYS = [...Object.keys(VALIDATE_MAP), 'validator'];
+export type ValidateFuncType = (typeof VALIDATE_MAP)[keyof typeof VALIDATE_MAP];
 
-export async function executeRule(value: any, rule: any, context?: any): Promise<ValidateResult> {
-  const resultType = getResultType(rule);
-
-  if (getRuleValue(rule.required) && isEmpty(value)) return fail(rule, resultType);
-  if (isEmpty(value)) return { result: true };
-
+/**
+ * 校验某一条数据的某一条规则，一种校验规则不满足则不再进行校验。
+ * @param value 值
+ * @param rule 校验规则
+ * @param context 表单上下文，包含 formData 和 name，供自定义校验器使用
+ * @returns 两种校验结果，一种是内置校验规则的校验结果哦，二种是自定义校验规则（validator）的校验结果
+ */
+export async function validateOneRule(
+  value: ValueType,
+  rule: FormRule,
+  context?: { formData: Data; name: string },
+): Promise<AllValidateResult> {
+  let validateResult: CustomValidateResolveType | ValidateResultType = { result: true };
   const keys = Object.keys(rule);
+  let vOptions: any;
+  let vValidateFun: ValidateFuncType | undefined;
+  let isValidatorRule = false;
   for (let i = 0; i < keys.length; i += 1) {
     const key = keys[i];
-    const validateFn = VALIDATE_MAP[key];
-    const ruleValue = getRuleValue(rule[key]);
-    if (validateFn && ruleValue !== undefined && ruleValue !== false) {
-      const options = ruleValue === true ? undefined : ruleValue;
-      if (!validateFn(value, options)) return fail(rule, resultType);
+    // 非必填选项，值为空，非自定义规则：无需校验，直接返回 true
+    if (!rule.required && isValueEmpty(value) && !rule.validator) {
+      return validateResult;
+    }
+    const validateRule: ValidateFuncType = VALIDATE_MAP[key as keyof typeof VALIDATE_MAP];
+    const ruleItem = rule[key as keyof FormRule];
+    // 找到一个校验规则，则无需再找，因为参数只允许对一个规则进行校验
+    if (validateRule && (ruleItem || ruleItem === 0)) {
+      // rule 值为 true 则表示没有校验参数，只是对值进行默认规则校验
+      vOptions = ruleItem === true ? undefined : ruleItem;
+      vValidateFun = validateRule;
+      isValidatorRule = key === 'validator';
+      break;
     }
   }
-
-  const validator = getRuleValue(rule.validator);
-  if (validator && !(await validator(value, context))) return fail(rule, resultType);
-
-  return { result: true };
+  if (vValidateFun) {
+    validateResult = isValidatorRule
+      ? await (vValidateFun as typeof VALIDATE_MAP.validator)(value, vOptions, context)
+      : await vValidateFun(value, vOptions);
+    // 如果校验不通过，则返回校验不通过的规则
+    if (isBoolean(validateResult)) {
+      return { ...rule, result: validateResult };
+    }
+    // 校验结果为对象，只有自定义校验规则会存在这种情况
+    if (isObject(validateResult)) {
+      return validateResult;
+    }
+  }
+  return validateResult;
 }
 
-export async function validateRules(value: any, rules: any[], context?: any): Promise<ValidateResult[]> {
-  return Promise.all(rules.map((rule) => executeRule(value, rule, context)));
+/**
+ * 单个数据进行全规则校验
+ * 保留 validateRules 别名以兼容已有调用
+ */
+export async function validate(value: any, rules: any[], context?: { formData: Data; name: string }): Promise<any[]> {
+  const all = rules.map((rule) => validateOneRule(value, rule, context));
+  const r = await Promise.all(all);
+  return r;
 }
+
+// 兼容已有导入
+export const validateRules = validate;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

#4283 补充内容

- 复用 h5 端工具函数

### 与 h5 端差异点
- 小程序端支持使用跨字段联动校验（小程序端 validateOneRule 支持传入 context ）
```js
// 场景：跨字段联动校验（如"确认密码"校验）
// 这是最典型的需要 context 的场景。在表单中，"确认密码"字段需要和"密码"字段进行对比：
Page({
  data: {
    formData: {
      password: '',
      confirmPassword: '',
    },
    formRules: {
      password: [
        { required: true, message: '请输入密码' },
      ],
      confirmPassword: [
        { required: true, message: '请确认密码' },
        {
          // ⬇️ 这里用了第二个参数 context
          validator: (val, context) => {
            return val === context.formData.password;
          },
          message: '两次输入的密码不一致',
        },
      ],
    },
  },
});

```
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram
<!--
- feat(组件名称): 处理问题或特性描述
--> 



#### @tdesign/uniapp
<!--
- feat(组件名称): 处理问题或特性描述
-->



#### @tdesign/uniapp-chat
<!--
- feat(组件名称): 处理问题或特性描述
-->



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
