### PR TITLE
feat(color-picker): add eyeDropper prop, emit eyedropper-tap event

### DIFF
--- a/packages/components/color-picker/color-picker.less
+++ b/packages/components/color-picker/color-picker.less
@@ -348,6 +348,29 @@
   }
 }
 
+.@{prefix}-color-picker {
+  &__eyedropper-wrap {
+    display: flex;
+    justify-content: flex-end;
+    padding: 8px 0 0;
+  }
+
+  &__eyedropper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    font-size: 18px;
+    border-radius: 4px;
+    cursor: pointer;
+
+    &:active {
+      opacity: 0.7;
+    }
+  }
+}
+
 .transparentBgImage () {
   /* stylelint-disable-next-line color-no-hex */
   background-image:

--- a/packages/components/color-picker/color-picker.ts
+++ b/packages/components/color-picker/color-picker.ts
@@ -398,5 +398,11 @@ export default class ColorPicker extends SuperComponent {
     onVisibleChange() {
       this.close('overlay');
     },
+
+    handleEyeDropperTap() {
+      this.triggerEvent('eyedropper-tap', {
+        color: getColorObject(this.color),
+      });
+    },
   };
 }

--- a/packages/components/color-picker/interfaces.ts
+++ b/packages/components/color-picker/interfaces.ts
@@ -9,4 +9,5 @@ export type ColorPickerChangeTrigger =
   | 'palette-brightness'
   | 'palette-hue-bar'
   | 'palette-alpha-bar'
-  | 'preset';
+  | 'preset'
+  | 'eyedropper';

--- a/packages/components/color-picker/props.ts
+++ b/packages/components/color-picker/props.ts
@@ -26,6 +26,10 @@ const props: TdColorPickerProps = {
     type: Boolean,
     value: true,
   },
+  eyeDropper: {
+    type: Boolean,
+    value: false,
+  },
   /** 如果 color-picker 是在一个 `position:fixed` 的区域，需要显式指定属性 fixed 为 true */
   fixed: {
     type: Boolean,

--- a/packages/components/color-picker/template.wxml
+++ b/packages/components/color-picker/template.wxml
@@ -58,6 +58,10 @@
       </view>
     </view>
 
+    <view wx:if="{{eyeDropper && isMultiple}}" class="{{classPrefix}}__eyedropper-wrap">
+      <view class="{{classPrefix}}__eyedropper" catch:tap="handleEyeDropperTap">🎨</view>
+    </view>
+
     <view class="{{classPrefix}}__format" wx:if="{{isMultiple}}">
       <view class="{{classPrefix}}__format-item {{classPrefix}}__format-item--first"> {{format}} </view>
       <view class="{{classPrefix}}__format-item {{classPrefix}}__format-item--second">


### PR DESCRIPTION
## 关联 Issue

closes Tencent/tdesign-common#2568

## 变更内容

- 新增 `eyeDropper` boolean prop
- 启用后在面板底部渲染吸色入口按钮
- 点击触发 `eyedropper-tap` 自定义事件（携带当前颜色对象），宿主应用可监听此事件实现自定义取色逻辑
- 小程序环境无原生 EyeDropper API，通过事件钩子为宿主应用提供扩展点