### PR TITLE
fix(Avatar): fallback to text when image load fails

### DIFF
--- a/packages/components/avatar/__test__/index.test.js
+++ b/packages/components/avatar/__test__/index.test.js
@@ -82,6 +82,18 @@ describe('Avatar & Avatar Groups', () => {
       await simulate.sleep(20);
       expect($wrapper.dom.style.display).toBe('none');
     });
+
+    it(':alt fallback when image load failed', async () => {
+      const comp = simulate.render(id);
+      comp.attach(document.createElement('parent-wrapper'));
+
+      const $image = comp.querySelector('.error-avatar-wrapper >>> #image');
+      $image.dispatchEvent('error');
+      await simulate.sleep(20);
+
+      const $text = comp.querySelector('.error-avatar-wrapper >>> .t-avatar__text');
+      expect($text.dom.textContent).toBe('avatar');
+    });
   });
 
   describe('Avatar Group Props', () => {

--- a/packages/components/avatar/avatar.ts
+++ b/packages/components/avatar/avatar.ts
@@ -26,6 +26,7 @@ export default class Avatar extends SuperComponent {
     prefix,
     classPrefix: name,
     isShow: true,
+    isImageLoadFailed: false,
     zIndex: 0,
     windowWidth: systemInfo.windowWidth,
   };
@@ -52,6 +53,11 @@ export default class Avatar extends SuperComponent {
         ...obj,
       });
     },
+    image() {
+      this.setData({
+        isImageLoadFailed: false,
+      });
+    },
   };
 
   methods = {
@@ -65,6 +71,10 @@ export default class Avatar extends SuperComponent {
       if (this.properties.hideOnLoadFailed) {
         this.setData({
           isShow: false,
+        });
+      } else {
+        this.setData({
+          isImageLoadFailed: true,
         });
       }
       this.triggerEvent('error', e.detail);

--- a/packages/components/avatar/avatar.wxml
+++ b/packages/components/avatar/avatar.wxml
@@ -28,7 +28,7 @@
       aria-hidden="{{ ariaHidden }}"
     >
       <t-image
-        wx:if="{{image}}"
+        wx:if="{{image && !isImageLoadFailed}}"
         t-class="{{prefix}}-image {{classPrefix}}__image"
         t-class-load="{{prefix}}-class-alt"
         style="{{imageProps && imageProps.style || ''}}"
@@ -42,12 +42,13 @@
         bind:error="onLoadError"
       />
       <template
-        wx:elif="{{iconName || _.isNoEmptyObj(iconData)}}"
+        wx:elif="{{!isImageLoadFailed && (iconName || _.isNoEmptyObj(iconData))}}"
         is="icon"
         data="{{tClass: classPrefix + '__icon ' + prefix + '-class-icon', name: iconName, ...iconData}}"
       />
       <view wx:else class="{{classPrefix}}__text {{prefix}}-class-content">
-        <slot />
+        <block wx:if="{{isImageLoadFailed && alt}}">{{alt}}</block>
+        <slot wx:else />
       </view>
     </view>
   </t-badge>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #2468

### 💡 需求背景和解决方案

Avatar 组件在配置 `image` 和 `alt` 时，图片加载失败后不会回退为字符头像展示，用户无法看到预期的替代文本。

本 PR 在图片加载失败且未开启 `hideOnLoadFailed` 时，将 Avatar 从图片态切换为字符头像态，并优先展示 `alt` 文本；当 `image` 地址变化时会重置加载失败状态，避免新图片仍停留在 fallback 状态。

同时新增单测覆盖图片加载失败后显示 `alt` 字符头像的行为。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram

- fix(Avatar): 图片加载失败时回退展示字符头像

#### @tdesign/uniapp

#### @tdesign/uniapp-chat

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供