### PR TITLE
feat(Form): support skyline render

### DIFF
--- a/packages/components/form-item/form-item.less
+++ b/packages/components/form-item/form-item.less
@@ -21,7 +21,7 @@
   --td-input-vertical-padding: 0;
   --td-textarea-padding: 0;
 
-  &:not(:last-child)::after {
+  &--bordered::after {
     .hairline-bottom(@form-item-border-color);
 
     left: @form-item-border-left-space;

--- a/packages/components/form-item/form-item.ts
+++ b/packages/components/form-item/form-item.ts
@@ -49,6 +49,7 @@ export default class FormItem extends SuperComponent {
     innerShowErrorMessage: true,
     innerContentAlign: '',
     contentStyle: '',
+    isLastChild: false,
   };
 
   observers = {

--- a/packages/components/form-item/form-item.ts
+++ b/packages/components/form-item/form-item.ts
@@ -45,7 +45,6 @@ export default class FormItem extends SuperComponent {
     formRules: [],
     innerLabelAlign: '',
     innerLabelWidth: '',
-    form: {},
     colon: false,
     innerShowErrorMessage: true,
     innerContentAlign: '',
@@ -67,51 +66,51 @@ export default class FormItem extends SuperComponent {
   relations: RelationsOptions = {
     '../form/form': {
       type: 'parent',
-      linked(target) {
-        target.registerChild(this);
-        this.form = target;
-        const { globalConfig } = this.data;
-        const { requiredMark, labelAlign, labelWidth, showErrorMessage } = this.properties;
-        const formRules = target.data.rules?.[this.properties.name];
-        const isRequired = formRules?.some((rule) => rule.required);
-
-        const { contentAlign } = this.properties;
-        const innerContentAlign = contentAlign || target.data.contentAlign || '';
-
-        this.setData({
-          formRules: formRules || [],
-          colon: target.data.colon,
-          innerLabelAlign: labelAlign || target.data.labelAlign,
-          innerLabelWidth: normalizeLabelWidth(labelWidth || target.data.labelWidth),
-          innerContentAlign,
-          contentStyle: innerContentAlign ? `text-align: ${innerContentAlign}` : '',
-          innerRequiredMark: requiredMark ?? target.data.requiredMark ?? globalConfig.requiredMark ?? isRequired,
-          innerShowErrorMessage:
-            typeof showErrorMessage === 'boolean' ? showErrorMessage : target.properties.showErrorMessage,
-          requiredMarkPosition: target.data.requiredMarkPosition || globalConfig.requiredMarkPosition || 'left',
-        });
-      },
-      unlinked() {
-        if (this.form) {
-          this.form.unregisterChild(this.properties.name);
-        }
+      // 关联建立时主动向父组件同步一次配置
+      linked() {
+        this.syncFromParent();
       },
     },
   };
 
   lifetimes = {
     ready() {
-      this.initFormItem();
-    },
-    /* istanbul ignore next */
-    detached() {
-      if (this.form) {
-        this.form.unregisterChild(this.properties.name);
-      }
+      // Skyline/glass-easel 下 relations.linked 可能未触发，ready 时再主动同步一次兜底
+      this.syncFromParent();
     },
   };
 
   methods = {
+    // 从父组件 t-form 同步配置（父 -> 子），集中处理「form-item 自身属性优先级高于 Form」的逻辑。
+    // 父组件引用统一通过 relations 注入的 $parent（基于 getRelationNodes）获取，兼容 Skyline 下 linked 仅触发一次的问题
+    syncFromParent() {
+      const parent = this.$parent;
+      if (!parent) return;
+
+      const { globalConfig } = this.data;
+      const { requiredMark, labelAlign, labelWidth, showErrorMessage, contentAlign, name } = this.properties;
+      const parentData = parent.data;
+
+      const formRules = parentData.rules?.[name];
+      const isRequired = formRules?.some((rule) => rule.required);
+      const innerContentAlign = contentAlign || parentData.contentAlign || '';
+
+      this.setData({
+        formRules: formRules || [],
+        colon: parentData.colon,
+        innerLabelAlign: labelAlign || parentData.labelAlign,
+        innerLabelWidth: normalizeLabelWidth(labelWidth || parentData.labelWidth),
+        innerContentAlign,
+        contentStyle: innerContentAlign ? `text-align: ${innerContentAlign}` : '',
+        innerRequiredMark: requiredMark ?? parentData.requiredMark ?? globalConfig.requiredMark ?? isRequired,
+        innerShowErrorMessage: typeof showErrorMessage === 'boolean' ? showErrorMessage : parentData.showErrorMessage,
+        requiredMarkPosition: parentData.requiredMarkPosition || globalConfig.requiredMarkPosition || 'left',
+      });
+
+      // 父组件可能在子组件之后才完成数据准备，这里主动同步初始值，避免 Skyline 下初始值丢失
+      this.setInitialValue();
+    },
+
     calcErrorClasses(errorList = this.data.errorList) {
       if (!this.data.innerShowErrorMessage) return '';
       if (!errorList || errorList.length === 0) return '';
@@ -135,24 +134,21 @@ export default class FormItem extends SuperComponent {
         });
     },
 
-    // 初始化表单项
-    initFormItem() {
-      this.setInitialValue();
-    },
-
     // 设置初始值
     setInitialValue() {
       const { name } = this.properties;
-      if (name && this.form) {
-        const data = this.form.properties.data || {};
+      const parent = this.$parent;
+      if (name && parent) {
+        const data = parent.properties.data || {};
         this.initialValue = data[name];
       }
     },
 
     // 获取表单数据
     getFormData() {
-      if (this.form) {
-        return this.form.properties.data || {};
+      const parent = this.$parent;
+      if (parent) {
+        return parent.properties.data || {};
       }
       return {};
     },
@@ -160,8 +156,9 @@ export default class FormItem extends SuperComponent {
     // 获取当前值
     getValue() {
       const { name } = this.properties;
-      if (name && this.form) {
-        const data = this.form.properties.data || {};
+      const parent = this.$parent;
+      if (name && parent) {
+        const data = parent.properties.data || {};
         return data[name];
       }
       return undefined;
@@ -218,7 +215,7 @@ export default class FormItem extends SuperComponent {
     // 分析验证结果
     analysisValidateResult(results) {
       const { globalConfig } = this.data;
-      const errorMessage = (this.form && this.form.properties.errorMessage) || globalConfig.errorMessage;
+      const errorMessage = this.$parent?.properties.errorMessage || globalConfig.errorMessage;
       const labelName = this.properties.label || this.properties.name;
 
       const errorList = results

--- a/packages/components/form-item/form-item.wxml
+++ b/packages/components/form-item/form-item.wxml
@@ -1,7 +1,7 @@
 <wxs src="../common/utils.wxs" module="_" />
 
 <view
-  class="{{classPrefix}} {{formItemClass}} {{formClass}}--{{innerLabelAlign}} {{formClass}}-item__{{name}} {{prefix}}-class"
+  class="{{classPrefix}} {{_.cls(formItemClass, [['bordered', !isLastChild]])}} {{formClass}}--{{innerLabelAlign}} {{formClass}}-item__{{name}} {{prefix}}-class"
   style="{{_._style([style, customStyle])}}"
 >
   <view class="{{formItemClass}}-wrap {{formItemClass}}--{{innerLabelAlign}} {{prefix}}-class-wrap">

--- a/packages/components/form/form.ts
+++ b/packages/components/form/form.ts
@@ -26,16 +26,25 @@ export default class Form extends SuperComponent {
   relations: RelationsOptions = {
     '../form-item/form-item': {
       type: 'child',
-      linked() {},
+      // 子组件挂载时主动下发一次表单配置，兼容 Skyline 下 linked 仅触发一次的情况
+      linked(target) {
+        target.syncFromParent?.();
+      },
     },
   };
 
   data = {
     prefix,
     classPrefix: name,
-    children: [],
     initialData: {},
     fields: [],
+  };
+
+  observers = {
+    // 父组件配置变化时，统一下发到所有 form-item，保证 父 -> 子 的属性同步
+    'labelAlign, labelWidth, colon, contentAlign, requiredMark, requiredMarkPosition, showErrorMessage, rules'() {
+      this.getChildren().forEach((child: any) => child.syncFromParent?.());
+    },
   };
 
   lifetimes = {
@@ -58,28 +67,19 @@ export default class Form extends SuperComponent {
       });
     },
 
-    // 注册子组件
-    registerChild(child) {
-      const { children } = this.data;
-      if (!children.find((item) => item.data.name === child.data.name)) {
-        children.push(child);
-        this.setData({ children });
+    // 获取所有 form-item 子组件
+    // 优先使用 relations 注入的 $children（基于 getRelationNodes，兼容 Skyline），兜底使用节点查询
+    getChildren() {
+      let items = this.$children;
+      if (!items?.length) {
+        items = this.selectAllComponents(`.${prefix}-form-item`);
       }
-    },
-
-    // 注销子组件
-    unregisterChild(childName) {
-      const { children } = this.data;
-      const index = children.findIndex((item) => item.data.name === childName);
-      if (index > -1) {
-        children.splice(index, 1);
-        this.setData({ children });
-      }
+      return items || [];
     },
 
     // 验证表单
     async validate() {
-      const { children } = this.data;
+      const children = this.getChildren();
       const { data } = this.properties;
       const validatePromises = children.map((child) => child.validate(data, 'all', this.properties.showErrorMessage));
 
@@ -110,7 +110,7 @@ export default class Form extends SuperComponent {
       const firstErrorKey = Object.keys(validateResult)[0];
       if (!firstErrorKey) return;
 
-      const { children } = this.data;
+      const children = this.getChildren();
       const errorChild = children.find((child) => child.properties.name === firstErrorKey);
       if (!errorChild) return;
 
@@ -120,7 +120,7 @@ export default class Form extends SuperComponent {
     // 纯净验证（不显示错误信息）
     async validateOnly(params) {
       const { fields, trigger = 'all' } = params;
-      const { children } = this.data;
+      const children = this.getChildren();
 
       const validatePromises = children
         .filter((child) => {
@@ -220,7 +220,8 @@ export default class Form extends SuperComponent {
 
     // 重置表单
     reset() {
-      const { children, initialData, fields } = this.data;
+      const children = this.getChildren();
+      const { initialData, fields } = this.data;
       const resetData = {};
 
       children.forEach((child) => {
@@ -241,7 +242,7 @@ export default class Form extends SuperComponent {
 
     // 清空验证结果
     clearValidate(fields) {
-      const { children } = this.data;
+      const children = this.getChildren();
 
       children.forEach((child) => {
         if (!fields || fields.includes(child.data.name)) {
@@ -252,7 +253,7 @@ export default class Form extends SuperComponent {
 
     // 设置验证信息
     setValidateMessage(validateMessage) {
-      const { children } = this.data;
+      const children = this.getChildren();
 
       children.forEach((child) => {
         if (validateMessage[child.data.name]) {

--- a/packages/components/form/form.ts
+++ b/packages/components/form/form.ts
@@ -29,6 +29,10 @@ export default class Form extends SuperComponent {
       // 子组件挂载时主动下发一次表单配置，兼容 Skyline 下 linked 仅触发一次的情况
       linked(target) {
         target.syncFromParent?.();
+        this.syncLastChildFlags();
+      },
+      unlinked() {
+        this.syncLastChildFlags();
       },
     },
   };
@@ -75,6 +79,11 @@ export default class Form extends SuperComponent {
         items = this.selectAllComponents(`.${prefix}-form-item`);
       }
       return items || [];
+    },
+
+    syncLastChildFlags() {
+      const items = this.getChildren();
+      items.forEach((child, index) => child.setData?.({ isLastChild: index === items.length - 1 }));
     },
 
     // 验证表单

--- a/packages/tdesign-miniprogram/.changelog/pr-4583.md
+++ b/packages/tdesign-miniprogram/.changelog/pr-4583.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4583
+contributor: anlyyao
+---
+
+- feat(Form): 适配 `skyline` 渲染引擎 @anlyyao ([#4583](https://github.com/Tencent/tdesign-miniprogram/pull/4583))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #4581 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

问题：Skyline 下，父子组件 linked 只触发一次
方案：
- 父子引用统一走框架的 $parent/$children，删除手动维护的 children/registerChild/this.form
- 属性同步统一为「父 push + 子 pull」双向兜底：集中到 form-item 的一个 syncFromParent() 方法；form 通过 observers 在属性变化时下发，form-item 在 linked/ready 时自拉，解决 Skyline 下 linked 仅触发一次的问题。


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- feat(Form): 适配 `skyline` 渲染引擎


#### @tdesign/uniapp
<!--
- feat(组件名称): 处理问题或特性描述
-->



#### @tdesign/uniapp-chat
<!--
- feat(组件名称): 处理问题或特性描述
-->



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
