### PR TITLE
feat(Cascader): support lazy loading

### DIFF
--- a/packages/components/cascader/README.en-US.md
+++ b/packages/components/cascader/README.en-US.md
@@ -14,6 +14,7 @@ filter | Function | - | Typescript: `CascaderFilterFunction ` `type CascaderFilt
 filter-placeholder | String | - | \- | N
 filterable | Boolean | false | \- | N
 keys | Object | - | Typescript: `CascaderKeysType` `type CascaderKeysType = TreeKeysType`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/cascader/type.ts) | N
+load | Function | - | loading subtree data (only effective when the node's children value is true)。Typescript: `(node: CascaderOption) => Promise<Array<CascaderOption>>` | N
 options | Array | [] | Typescript: `Array<CascaderOption>` | N
 placeholder | String | - | \- | N
 sub-titles | Array | [] | Typescript: `Array<string>` | N

--- a/packages/components/cascader/README.md
+++ b/packages/components/cascader/README.md
@@ -72,6 +72,7 @@ filter | Function | - |  自定义过滤函数。返回 true 表示匹配，未�
 filter-placeholder | String | - | 搜索框占位符描述文本 | N
 filterable | Boolean | false | 是否可搜索，开启后顶部会展示一个搜索框  | N
 keys | Object | - | 用来定义 value / label / children / disabled 在 `options` 中对应的字段别名。TS 类型：`CascaderKeysType` `type CascaderKeysType = TreeKeysType`。[通用类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/cascader/type.ts) | N
+load | Function | - | 加载子树数据的方法（仅当节点 children 为 true 时生效）。TS 类型：`(node: CascaderOption) => Promise<Array<CascaderOption>>` | N
 options | Array | [] | 可选项数据源。TS 类型：`Array<CascaderOption>` | N
 placeholder | String | - | 未选中时的提示文案。组件内置默认值为：'选择选项' | N
 sub-titles | Array | [] | 每级展示的次标题。TS 类型：`Array<string>` | N

--- a/packages/components/cascader/__test__/__snapshots__/demo.test.js.snap
+++ b/packages/components/cascader/__test__/__snapshots__/demo.test.js.snap
@@ -752,6 +752,33 @@ exports[`Cascader Cascader keys demo works fine 1`] = `
 </keys>
 `;
 
+exports[`Cascader Cascader lazy-load demo works fine 1`] = `
+<lazy-load>
+  <t-cell
+    arrow="{{true}}"
+    note="中国/广东省/深圳市"
+    title="地址"
+    bind:click="showCascader"
+  />
+  <t-cascader
+    load="{{[Function]}}"
+    options="{{
+      Array [
+        Object {
+          "children": true,
+          "label": "中国",
+          "value": "CN",
+        },
+      ]
+    }}"
+    title="请选择地址"
+    value="440300"
+    visible="{{false}}"
+    bind:change="onChange"
+  />
+</lazy-load>
+`;
+
 exports[`Cascader Cascader theme-tab demo works fine 1`] = `
 <theme-tab>
   <t-cell

--- a/packages/components/cascader/__test__/demo.test.js
+++ b/packages/components/cascader/__test__/demo.test.js
@@ -5,7 +5,7 @@
 import path from 'path';
 import simulate from 'miniprogram-simulate';
 
-const mapper = ['base', 'check-strictly', 'filterable', 'keys', 'theme-tab', 'with-title', 'with-value'];
+const mapper = ['base', 'check-strictly', 'filterable', 'keys', 'lazy-load', 'theme-tab', 'with-title', 'with-value'];
 
 describe('Cascader', () => {
   mapper.forEach((demoName) => {

--- a/packages/components/cascader/__test__/index.test.js
+++ b/packages/components/cascader/__test__/index.test.js
@@ -138,4 +138,139 @@ describe('cascader', () => {
       expect(leaf.value).toBe('110108');
     });
   });
+
+  describe(': lazy load', () => {
+    const renderCascader = ({ options, value = null, load, keys } = {}) => {
+      const id = simulate.load({
+        template: `<t-cascader id="cas" options="{{options}}" value="{{value}}" load="{{load}}" keys="{{keys}}" />`,
+        data: { options, value, load, keys },
+        usingComponents: { 't-cascader': cascader },
+      });
+      const comp = simulate.render(id);
+      comp.attach(document.createElement('parent-wrapper'));
+      return comp;
+    };
+
+    const select = ($cascader, level, value) => {
+      $cascader.instance.handleSelect({
+        target: { dataset: { level } },
+        detail: { value },
+      });
+    };
+
+    it('loads children:true nodes on selection without mutating options', async () => {
+      const options = [{ label: '中国', value: 'CN', children: true }];
+      const load = jest.fn(() => Promise.resolve([{ label: '广东省', value: '440000' }]));
+      const comp = renderCascader({ options, load });
+      const $cascader = comp.querySelector('#cas');
+
+      expect(load).not.toHaveBeenCalled();
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+
+      expect(load).toHaveBeenCalledTimes(1);
+      expect(load.mock.calls[0][0]).toMatchObject({ label: '中国', value: 'CN' });
+      expect($cascader.instance.data.items[1]).toEqual([{ label: '广东省', value: '440000', disabled: undefined }]);
+      expect(options[0].children).toBe(true);
+    });
+
+    it('initializes a value whose full path already exists', () => {
+      const options = [
+        {
+          label: '中国',
+          value: 'CN',
+          children: [{ label: '深圳市', value: '440300' }],
+        },
+      ];
+      const load = jest.fn();
+      const comp = renderCascader({ options, value: '440300', load });
+      const $cascader = comp.querySelector('#cas');
+
+      expect($cascader.instance.data.selectedIndexes).toEqual([0, 0]);
+      expect($cascader.instance.data.selectedValue).toEqual(['CN', '440300']);
+      expect(load).not.toHaveBeenCalled();
+    });
+
+    it('restores an unresolved value after its path is loaded', async () => {
+      const options = [{ label: '中国', value: 'CN', children: true }];
+      const load = jest.fn((node) => {
+        if (node.value === 'CN') {
+          return Promise.resolve([{ label: '广东省', value: '440000', children: true }]);
+        }
+        return Promise.resolve([{ label: '深圳市', value: '440300' }]);
+      });
+      const comp = renderCascader({ options, value: '440300', load });
+      const $cascader = comp.querySelector('#cas');
+      const triggerChange = jest.spyOn($cascader.instance, 'triggerChange');
+
+      expect($cascader.instance.data.selectedIndexes).toEqual([]);
+      expect(load).not.toHaveBeenCalled();
+
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+      expect($cascader.instance.data.selectedIndexes).toEqual([0]);
+
+      select($cascader, 1, '440000');
+      await simulate.sleep();
+
+      expect(load).toHaveBeenCalledTimes(2);
+      expect($cascader.instance.data.selectedIndexes).toEqual([0, 0, 0]);
+      expect($cascader.instance.data.selectedValue).toEqual(['CN', '440000', '440300']);
+      expect(triggerChange).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates an in-flight request and caches the loaded children', async () => {
+      let resolveLoad;
+      const load = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveLoad = resolve;
+          }),
+      );
+      const comp = renderCascader({ options: [{ label: '中国', value: 'CN', children: true }], load });
+      const $cascader = comp.querySelector('#cas');
+
+      select($cascader, 0, 'CN');
+      select($cascader, 0, 'CN');
+      expect(load).toHaveBeenCalledTimes(1);
+
+      resolveLoad([{ label: '广东省', value: '440000' }]);
+      await simulate.sleep();
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+
+      expect(load).toHaveBeenCalledTimes(1);
+      expect($cascader.instance.data.items[1][0].value).toBe('440000');
+    });
+
+    it('keeps children:true after a rejected request so it can retry', async () => {
+      const load = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce([{ label: '广东省', value: '440000' }]);
+      const comp = renderCascader({ options: [{ label: '中国', value: 'CN', children: true }], load });
+      const $cascader = comp.querySelector('#cas');
+
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+
+      expect(load).toHaveBeenCalledTimes(2);
+      expect($cascader.instance.data.items[1][0].value).toBe('440000');
+    });
+
+    it('supports lazy loading with custom keys', async () => {
+      const keys = { label: 'name', value: 'code', children: 'nodes', disabled: 'blocked' };
+      const load = jest.fn(() => Promise.resolve([{ name: '广东省', code: '440000' }]));
+      const comp = renderCascader({ options: [{ name: '中国', code: 'CN', nodes: true }], load, keys });
+      const $cascader = comp.querySelector('#cas');
+
+      select($cascader, 0, 'CN');
+      await simulate.sleep();
+
+      expect(load).toHaveBeenCalledTimes(1);
+      expect($cascader.instance.data.items[1]).toEqual([{ name: '广东省', code: '440000', blocked: undefined }]);
+    });
+  });
 });

--- a/packages/components/cascader/_example/cascader.json
+++ b/packages/components/cascader/_example/cascader.json
@@ -7,6 +7,7 @@
     "with-value": "./with-value",
     "with-title": "./with-title",
     "check-strictly": "./check-strictly",
+    "lazy-load": "./lazy-load",
     "filterable": "./filterable"
   }
 }

--- a/packages/components/cascader/_example/cascader.wxml
+++ b/packages/components/cascader/_example/cascader.wxml
@@ -24,6 +24,10 @@
     <check-strictly />
   </t-demo>
 
+  <t-demo desc="懒加载选项">
+    <lazy-load />
+  </t-demo>
+
   <t-demo desc="支持搜索">
     <filterable />
   </t-demo>

--- a/packages/components/cascader/_example/lazy-load/index.js
+++ b/packages/components/cascader/_example/lazy-load/index.js
@@ -1,0 +1,33 @@
+const childrenMap = {
+  CN: [{ label: '广东省', value: '440000', children: true }],
+  440000: [
+    { label: '广州市', value: '440100' },
+    { label: '深圳市', value: '440300' },
+  ],
+};
+
+Component({
+  data: {
+    options: [{ label: '中国', value: 'CN', children: true }],
+    value: '440300',
+    visible: false,
+    note: '中国/广东省/深圳市',
+    load(node) {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(childrenMap[node.value] || []), 500);
+      });
+    },
+  },
+  methods: {
+    showCascader() {
+      this.setData({ visible: true });
+    },
+    onChange(e) {
+      const { value, selectedOptions } = e.detail;
+      this.setData({
+        value,
+        note: selectedOptions.map((item) => item.label).join('/'),
+      });
+    },
+  },
+});

--- a/packages/components/cascader/_example/lazy-load/index.json
+++ b/packages/components/cascader/_example/lazy-load/index.json
@@ -1,0 +1,7 @@
+{
+  "component": true,
+  "usingComponents": {
+    "t-cell": "tdesign-miniprogram/cell/cell",
+    "t-cascader": "tdesign-miniprogram/cascader/cascader"
+  }
+}

--- a/packages/components/cascader/_example/lazy-load/index.wxml
+++ b/packages/components/cascader/_example/lazy-load/index.wxml
@@ -1,0 +1,10 @@
+<t-cell title="地址" note="{{note}}" bind:click="showCascader" arrow />
+
+<t-cascader
+  visible="{{visible}}"
+  value="{{value}}"
+  options="{{options}}"
+  load="{{load}}"
+  title="请选择地址"
+  bind:change="onChange"
+/>

--- a/packages/components/cascader/cascader.ts
+++ b/packages/components/cascader/cascader.ts
@@ -36,7 +36,7 @@ function parseOptions(options: OptionsType, keys: KeysType) {
   const value = keys?.value ?? 'value';
   const disabled = keys?.disabled ?? 'disabled';
 
-  return options.map((item) => ({
+  return (options || []).map((item) => ({
     [label]: item[label],
     [value]: item[value],
     [disabled]: item[disabled],
@@ -55,25 +55,44 @@ function flattenPaths(options: OptionsType, keys: KeysType): FlatPath[] {
       const nextPath = [...path, item];
       const nextIndexes = [...indexes, idx];
       const children = item?.[childrenKey];
+
+      if (children === true) {
+        return;
+      }
+
       if (Array.isArray(children) && children.length > 0) {
         walk(children, nextPath, nextIndexes);
-      } else {
-        const labels = nextPath.map((node) => String(node?.[labelKey] ?? ''));
-        const text = [labels.join(''), String(item?.text ?? '')].filter(Boolean).join('');
-        result.push({
-          key: nextPath.map((node) => String(node?.[valueKey] ?? '')).join('/'),
-          path: nextPath,
-          indexes: nextIndexes,
-          labels,
-          text,
-          disabled: nextPath.some((node) => node?.[disabledKey]),
-        });
+        return;
       }
+
+      const labels = nextPath.map((node) => String(node?.[labelKey] ?? ''));
+      const text = [labels.join(''), String(item?.text ?? '')].filter(Boolean).join('');
+      result.push({
+        key: nextPath.map((node) => String(node?.[valueKey] ?? '')).join('/'),
+        path: nextPath,
+        indexes: nextIndexes,
+        labels,
+        text,
+        disabled: nextPath.some((node) => node?.[disabledKey]),
+      });
     });
   };
 
   walk(options || [], [], []);
   return result;
+}
+
+function cloneOptions(options: OptionsType, keys: KeysType): OptionsType {
+  const childrenKey = keys?.children ?? 'children';
+
+  return (options || []).map((item) => {
+    const cloned = { ...item };
+    const children = item?.[childrenKey];
+    if (Array.isArray(children)) {
+      cloned[childrenKey] = cloneOptions(children, keys);
+    }
+    return cloned;
+  });
 }
 
 function buildFragments(labels: string[], keyword: string): ResultFragment[] {
@@ -137,6 +156,14 @@ export default class Cascader extends SuperComponent {
 
   filterDebounced: ((value: string) => void) | null = null;
 
+  optionTree: OptionsType = [];
+
+  optionTreeInitialized = false;
+
+  optionTreeVersion = 0;
+
+  loadingNodes = new Set<object>();
+
   controlledProps = [
     {
       key: 'value',
@@ -186,9 +213,12 @@ export default class Cascader extends SuperComponent {
     },
 
     options() {
-      const { selectedValue, steps, items } = this.genItems();
+      this.syncOptionTree();
+      const selectedIndexes = this.getSelectedIndexesByValue();
+      const { selectedValue, steps, items } = this.genItems(selectedIndexes);
 
       this.setData({
+        selectedIndexes,
         steps,
         items,
         selectedValue,
@@ -202,6 +232,16 @@ export default class Cascader extends SuperComponent {
     },
 
     keys() {
+      this.syncOptionTree();
+      const selectedIndexes = this.getSelectedIndexesByValue();
+      const { selectedValue, steps, items } = this.genItems(selectedIndexes);
+      this.setData({
+        selectedIndexes,
+        steps,
+        items,
+        selectedValue,
+        stepIndex: items.length - 1,
+      });
       this.invalidateFlatPaths();
       if (this.data.isSearching) {
         this.applyFilter(this.data.filterKeyword);
@@ -286,26 +326,36 @@ export default class Cascader extends SuperComponent {
     },
 
     initWithValue() {
-      if (this.data.value != null && this.data.value !== '') {
-        const selectedIndexes = this.getIndexesByValue(this.data.options, this.data.value);
-
-        if (selectedIndexes) {
-          this.setData({ selectedIndexes });
-        }
-      } else {
-        this.setData({ selectedIndexes: [] });
+      this.setData({ selectedIndexes: this.getSelectedIndexesByValue() });
+    },
+    syncOptionTree() {
+      this.optionTree = cloneOptions(this.data.options, this.data.keys);
+      this.optionTreeInitialized = true;
+      this.optionTreeVersion += 1;
+      this.loadingNodes = new Set<object>();
+    },
+    getOptionTree() {
+      if (!this.optionTreeInitialized) {
+        this.syncOptionTree();
       }
+      return this.optionTree;
+    },
+    getSelectedIndexesByValue() {
+      const { value } = this.data;
+      if (value == null || value === '') return [];
+      return this.getIndexesByValue(this.getOptionTree(), value) || [];
     },
     getIndexesByValue(options: OptionsType, value) {
       const { keys } = this.data;
 
-      for (let i = 0, size = options.length; i < size; i += 1) {
+      for (let i = 0, size = options?.length || 0; i < size; i += 1) {
         const opt = options[i];
         if (opt[keys?.value ?? 'value'] === value) {
           return [i];
         }
-        if (opt[keys?.children ?? 'children']) {
-          const res = this.getIndexesByValue(opt[keys?.children ?? 'children'], value);
+        const children = opt[keys?.children ?? 'children'];
+        if (Array.isArray(children)) {
+          const res = this.getIndexesByValue(children, value);
           if (res) {
             return [i, ...res];
           }
@@ -344,8 +394,8 @@ export default class Cascader extends SuperComponent {
     ensureFlatPaths() {
       let { flatPaths } = this.state;
       if (!flatPaths || flatPaths.length === 0) {
-        const { options, keys } = this.data;
-        flatPaths = flattenPaths(options, keys);
+        const { keys } = this.data;
+        flatPaths = flattenPaths(this.getOptionTree(), keys);
         this.state.flatPaths = flatPaths;
       }
       return flatPaths;
@@ -422,7 +472,8 @@ export default class Cascader extends SuperComponent {
       this.hide('finish');
     },
     regenItemsByIndexes(selectedIndexes: number[]) {
-      const { options, keys, placeholder, globalConfig } = this.data;
+      const { keys, placeholder, globalConfig } = this.data;
+      const options = this.getOptionTree();
       const selectedValue: any[] = [];
       const steps: string[] = [];
       const items: any[] = [parseOptions(options, keys)];
@@ -461,8 +512,10 @@ export default class Cascader extends SuperComponent {
         stepIndex: value,
       });
     },
-    genItems() {
-      const { options, selectedIndexes, keys, placeholder, globalConfig } = this.data;
+    genItems(indexes = this.data.selectedIndexes) {
+      const { keys, placeholder, globalConfig } = this.data;
+      const options = this.getOptionTree();
+      const selectedIndexes = indexes || [];
       const selectedValue = [];
       const steps = [];
       const items = [parseOptions(options, keys)];
@@ -471,14 +524,16 @@ export default class Cascader extends SuperComponent {
         let current = options;
         for (let i = 0, size = selectedIndexes.length; i < size; i += 1) {
           const index = selectedIndexes[i];
-          const next = current[index];
-          current = next[keys?.children ?? 'children'];
+          const next = current?.[index];
+          if (!next) break;
+          const children = next[keys?.children ?? 'children'];
 
           selectedValue.push(next[keys?.value ?? 'value']);
           steps.push(next[keys?.label ?? 'label']);
 
-          if (next[keys?.children ?? 'children']) {
-            items.push(parseOptions(next[keys?.children ?? 'children'], keys));
+          if (Array.isArray(children) && children.length > 0) {
+            items.push(parseOptions(children, keys));
+            current = children;
           }
         }
       }
@@ -497,7 +552,9 @@ export default class Cascader extends SuperComponent {
       const { level } = e.target.dataset;
       const { value } = e.detail;
       const { checkStrictly } = this.properties;
-      const { selectedIndexes, items, keys, options, selectedValue } = this.data;
+      const { items, keys, selectedValue } = this.data;
+      const selectedIndexes = [...this.data.selectedIndexes];
+      const options = this.getOptionTree();
       const index = items[level].findIndex((item) => item[keys?.value ?? 'value'] === value);
 
       let item = selectedIndexes.slice(0, level).reduce((acc, item, index) => {
@@ -530,8 +587,12 @@ export default class Cascader extends SuperComponent {
       }
       selectedIndexes.length = level + 1;
 
-      const { items: newItems } = this.genItems();
-      if (item?.[keys?.children ?? 'children']?.length >= 0) {
+      const children = item?.[keys?.children ?? 'children'];
+      if (children === true && typeof this.data.load === 'function') {
+        this.setData({ selectedIndexes });
+        this.loadChildren(item, selectedIndexes);
+      } else if (Array.isArray(children) && children.length > 0) {
+        const { items: newItems } = this.genItems(selectedIndexes);
         this.setData({
           selectedIndexes,
           [`items[${level + 1}]`]: newItems[level + 1],
@@ -546,6 +607,67 @@ export default class Cascader extends SuperComponent {
         );
         this.hide('finish');
       }
+    },
+    async loadChildren(item: Record<string, any>, selectedIndexes: number[]) {
+      if (this.loadingNodes.has(item)) return;
+
+      const { keys, load } = this.data;
+      if (typeof load !== 'function') return;
+      const childrenKey = keys?.children ?? 'children';
+      const version = this.optionTreeVersion;
+      this.loadingNodes.add(item);
+
+      try {
+        const result = await load(item);
+        if (version !== this.optionTreeVersion) return;
+
+        const children = cloneOptions(Array.isArray(result) ? result : [], keys);
+        item[childrenKey] = children;
+        this.invalidateFlatPaths();
+
+        if (this.data.isSearching) {
+          this.applyFilter(this.data.filterKeyword);
+        }
+
+        const current = this.getOptionByIndexes(this.data.selectedIndexes);
+        if (current !== item) return;
+
+        const matchedIndexes = this.getIndexesByValue(children, this.data.value);
+        const nextIndexes = matchedIndexes ? [...selectedIndexes, ...matchedIndexes] : selectedIndexes;
+        const { selectedValue, steps, items } = this.genItems(nextIndexes);
+        this.setData(
+          {
+            selectedIndexes: nextIndexes,
+            selectedValue,
+            steps,
+            items,
+            stepIndex: items.length - 1,
+          },
+          children.length === 0
+            ? () => {
+                this.triggerChange();
+                this.hide('finish');
+              }
+            : undefined,
+        );
+      } catch {
+        // Keep children as true so the user can retry loading the node.
+      } finally {
+        this.loadingNodes.delete(item);
+      }
+    },
+    getOptionByIndexes(selectedIndexes: number[]) {
+      const childrenKey = this.data.keys?.children ?? 'children';
+      let current: any = this.getOptionTree();
+      let option: any;
+
+      for (let i = 0; i < selectedIndexes.length; i += 1) {
+        if (!Array.isArray(current)) return undefined;
+        option = current[selectedIndexes[i]];
+        if (!option) return undefined;
+        current = option[childrenKey];
+      }
+      return option;
     },
     triggerChange() {
       const { items, selectedValue, selectedIndexes } = this.data;

--- a/packages/components/cascader/props.ts
+++ b/packages/components/cascader/props.ts
@@ -34,6 +34,10 @@ const props: TdCascaderProps = {
   keys: {
     type: Object,
   },
+  /** 加载子树数据的方法（仅当节点 children 为 true 时生效） */
+  load: {
+    type: null,
+  },
   /** 可选项数据源 */
   options: {
     type: Array,

--- a/packages/components/cascader/type.ts
+++ b/packages/components/cascader/type.ts
@@ -54,6 +54,13 @@ export interface TdCascaderProps<CascaderOption extends TreeOptionData = TreeOpt
     value?: CascaderKeysType;
   };
   /**
+   * 加载子树数据的方法（仅当节点 children 为 true 时生效）
+   */
+  load?: {
+    type: undefined;
+    value?: (node: CascaderOption) => Promise<Array<CascaderOption>>;
+  };
+  /**
    * 可选项数据源
    * @default []
    */


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Fixes #4189
- API 同步 PR：TDesignOteam/tdesign-api#966

### 💡 需求背景和解决方案

Cascader 目前会将 `children: true` 当作普通叶子节点处理，无法在用户展开节点时按需加载下一级数据。

本 PR：

1. 新增 `load(node) => Promise<CascaderOption[]>`，仅在点击 `children: true` 的节点时调用。
2. 使用组件内部 options 树缓存加载结果，避免修改业务传入的 `options`。
3. 同一节点请求进行中时去重；请求失败后保留 `children: true`，允许再次点击重试；`options` 更新后忽略旧请求结果。
4. 初始 `value` 的完整路径已存在时保持原有初始化行为；路径尚未加载时不自动递归请求，用户逐级展开后，若新子树包含当前 `value`，自动恢复完整选中路径，不触发 `change` 或关闭面板。
5. 支持自定义 `keys`，并补充懒加载示例、单元测试及 API 文档。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram

- feat(Cascader): 支持通过 `load` 懒加载 `children: true` 节点并恢复初始值

#### @tdesign/uniapp



#### @tdesign/uniapp-chat



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### ✅ 验证

- Cascader 单元测试与示例测试：21 项通过
- `pnpm run build`
- ESLint、Prettier、`git diff --check`
