### PR TITLE
fix(Message): 修复 Android 页面后退重进卡死

### DIFF
--- a/packages/components/message-item/message-item.ts
+++ b/packages/components/message-item/message-item.ts
@@ -94,7 +94,7 @@ export default class Message extends SuperComponent {
       this.memoInitialData();
     },
     detached() {
-      this.clearMessageAnimation();
+      this.reset();
     },
   };
 

--- a/packages/components/message/__test__/index.test.js
+++ b/packages/components/message/__test__/index.test.js
@@ -182,6 +182,53 @@ describe('message', () => {
     });
   });
 
+  describe('lifecycle', () => {
+    it(': clears the duration timer when detached', () => {
+      const messageItem = load(path.resolve(__dirname, `../../message-item/message-item`), 't-message-item');
+      const comp = simulate.render(messageItem, {
+        content: 'message before navigate back',
+        duration: 5000,
+        offset: [20, 32],
+      });
+      comp.attach(document.createElement('parent-wrapper'));
+
+      comp.instance.show();
+      expect(comp.instance.closeTimeoutContext).not.toBe(0);
+
+      comp.detach();
+      const { closeTimeoutContext } = comp.instance;
+      if (closeTimeoutContext) clearTimeout(closeTimeoutContext);
+      expect(closeTimeoutContext).toBe(0);
+    });
+
+    it(': hides each message at most once when an instance cannot remove itself', () => {
+      const id = simulate.load({
+        template: `<t-message id="t-message" />`,
+        usingComponents: {
+          't-message': message,
+        },
+      });
+      const comp = simulate.render(id);
+      comp.attach(document.createElement('parent-wrapper'));
+      const $message = comp.querySelector('#t-message');
+      const firstHide = jest
+        .fn()
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('hide called repeatedly');
+        });
+      const secondHide = jest.fn();
+
+      $message.instance.instances = [{ hide: firstHide }, { hide: secondHide }];
+
+      expect(() => $message.instance.hideAll()).not.toThrow();
+      expect(firstHide).toHaveBeenCalledTimes(1);
+      expect(secondHide).toHaveBeenCalledTimes(1);
+      $message.instance.instances = [];
+      comp.detach();
+    });
+  });
+
   describe('multiple', () => {
     it(': message-count-gap', async () => {
       const id = simulate.load({

--- a/packages/components/message/message.ts
+++ b/packages/components/message/message.ts
@@ -110,7 +110,7 @@ export default class Message extends SuperComponent {
       () => {
         const offsetHeight = this.getOffsetHeight();
         const instance = this.showMessageItem(msgObj, msgObj.id, offsetHeight);
-        if (this.instances) {
+        if (instance) {
           this.instances.push(instance);
           this.index += 1;
         }
@@ -146,11 +146,11 @@ export default class Message extends SuperComponent {
   showMessageItem(options: MessageProps, id: string, offsetHeight: number) {
     const instance = this.selectComponent(`#${id}`);
     if (instance) {
+      instance.onHide = () => {
+        this.close(id);
+      };
       instance.resetData(() => {
         instance.setData(options, instance.show.bind(instance, offsetHeight));
-        instance.onHide = () => {
-          this.close(id);
-        };
       });
 
       return instance;
@@ -183,11 +183,8 @@ export default class Message extends SuperComponent {
    * 移除全部消息
    */
   hideAll() {
-    // 消息移除后也会移除instance，下标不用增加，直至全部删除
-    for (let i = 0; i < this.instances.length; ) {
-      const instance = this.instances[i];
-      instance.hide();
-    }
+    // 使用快照，避免依赖子实例在 hide 回调中同步修改 instances。
+    [...this.instances].forEach((instance) => instance?.hide());
   }
 
   /**


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Closes #3576

### 💡 需求背景和解决方案

Android 部分机型在 Message 尚未自动关闭时返回上一页，随后重新进入页面，可能出现页面卡死。

根因有两处：

1. MessageItem 销毁时只清理跑马灯动画定时器，未清理 duration 自动关闭定时器，导致已销毁实例仍可能收到异步回调。
2. Message.hideAll() 遍历可变实例数组时不递增下标，依赖每个子实例在 hide 回调中同步移除自身；页面切换时遇到失效或尚未完成初始化的实例会反复调用同一实例，阻塞主线程。

本 PR：

- 在 MessageItem detached 生命周期中统一重置动画和自动关闭定时器；
- 在异步初始化前绑定 onHide，并只记录成功获取的子实例；
- 基于实例快照执行 hideAll，保证每个实例最多处理一次；
- 补充页面销毁清理定时器及异常实例有限遍历的回归测试。

### ✅ 验证

- pnpm exec prettier --check：通过
- pnpm run lint：通过
- pnpm run build:dist：通过
- Jest 全量单测：138 个套件、790 个测试、397 个快照全部通过

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram

- fix(Message): 修复 Android 页面后退重进时可能卡死的问题

#### @tdesign/uniapp


#### @tdesign/uniapp-chat


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
