### PR TITLE
fix(Tag): fix close event also triggering click event when tapping close icon

### DIFF
--- a/packages/components/tag/__test__/index.test.js
+++ b/packages/components/tag/__test__/index.test.js
@@ -275,6 +275,8 @@ describe('tag', () => {
           $close.dispatchEvent('tap');
           await simulate.sleep(10);
           expect(handleClose).toHaveBeenCalledTimes(1);
+          // close 事件触发时，不应同时触发 click 事件
+          expect(handleClick).toHaveBeenCalledTimes(1);
         }
       });
     });

--- a/packages/components/tag/tag.wxml
+++ b/packages/components/tag/tag.wxml
@@ -13,10 +13,15 @@
   <view class="{{classPrefix}}__text">
     <slot />
   </view>
-  <template
+  <t-icon
     wx:if="{{_closable}}"
-    is="icon"
-    data="{{tClass: classPrefix + '__icon-close ' + prefix + '-icon', bindclick: 'handleClose',  ariaRole: 'button', ariaLabel: '关闭',  ..._closable }}"
+    class="{{classPrefix}}__icon-close {{prefix}}-icon"
+    prefix="{{_closable.prefix || ''}}"
+    name="{{_closable.name || ''}}"
+    size="{{_closable.size || ''}}"
+    color="{{_closable.color || ''}}"
+    aria-role="button"
+    aria-label="关闭"
     catch:tap="handleClose"
   />
   <slot wx:else name="closable" />

--- a/packages/tdesign-miniprogram/.changelog/pr-4611.md
+++ b/packages/tdesign-miniprogram/.changelog/pr-4611.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4611
+contributor: anlyyao
+---
+
+- fix(Tag): 修复关闭图标点击时同时触发 `click` 事件的问题 @anlyyao ([#4611](https://github.com/Tencent/tdesign-miniprogram/pull/4611))

--- a/packages/tdesign-uniapp/.changelog/pr-4611.md
+++ b/packages/tdesign-uniapp/.changelog/pr-4611.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4611
+contributor: anlyyao
+---
+
+- fix(Tag): 修复关闭图标点击时同时触发 `click` 事件的问题 @anlyyao ([#4611](https://github.com/Tencent/tdesign-miniprogram/pull/4611))

--- a/packages/uniapp-components/tag/tag.vue
+++ b/packages/uniapp-components/tag/tag.vue
@@ -30,7 +30,7 @@
         :aria-hidden="!!innerClosable.ariaHidden"
         :aria-label="innerClosable.ariaLabel || '关闭'"
         :aria-role="innerClosable.ariaRole"
-        @click="handleClose"
+        @click.stop="handleClose"
       />
     </block>
     <slot v-else name="closable" />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #4609 
fix #4617 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
背景：点击关闭标签时，会同时触发点击事件

方案：关闭图标从 icon 模板改为直接渲染的 <t-icon>，把拦截冒泡的 catch:tap 放到真实渲染的组件节点上

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Tag): 修复关闭图标点击时同时触发 `click` 事件的问题


#### @tdesign/uniapp
<!--
- feat(组件名称): 处理问题或特性描述
-->
- fix(Tag): 修复关闭图标点击时同时触发 `click` 事件的问题


#### @tdesign/uniapp-chat
<!--
- feat(组件名称): 处理问题或特性描述
-->



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
