### PR TITLE
fix(fab): 修复collapsible模式collapseDuration属性渲染插值语法问题支持自动收缩模式

### DIFF
--- a/packages/components/fab/README.en-US.md
+++ b/packages/components/fab/README.en-US.md
@@ -9,6 +9,8 @@ name | type | default | description | required
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
 button-props | Object | - | Typescript: `ButtonProps`，[Button API Documents](./button?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/fab/type.ts) | N
+collapse-duration | Number | 3000 | auto-collapse delay in milliseconds | N
+collapsible | Boolean | false | whether to enable auto-collapse | N
 draggable | String / Boolean | false | Typescript: `boolean \| FabDirectionEnum ` `type FabDirectionEnum = 'all' \| 'vertical' \| 'horizontal'`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/fab/type.ts) | N
 icon | String / Object | - | icon name | N
 text | String | - | \- | N

--- a/packages/components/fab/README.md
+++ b/packages/components/fab/README.md
@@ -68,6 +68,8 @@ Fab 组件默认定位 `right: 16px; bottom: 32px;`，且拖拽功能也是通�
 style | Object | - | 样式 | N
 custom-style | Object | - | 样式，一般用于开启虚拟化组件节点场景 | N
 button-props | Object | - | 透传至 Button 组件。TS 类型：`ButtonProps`，[Button API Documents](./button?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/fab/type.ts) | N
+collapse-duration | Number | 3000 | 自动收缩延迟时间，单位毫秒 | N
+collapsible | Boolean | false | 是否开启自动收缩 | N
 draggable | String / Boolean | false | 是否可拖拽。`true` / `'all'`可拖动<br>`'vertical'`可垂直拖动<br>`'horizontal'`可水平拖动<br>`false`禁止拖动。TS 类型：`boolean \| FabDirectionEnum ` `type FabDirectionEnum = 'all' \| 'vertical' \| 'horizontal'`。[详细类型定义](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/fab/type.ts) | N
 icon | String / Object | - | 图标名称。值为字符串表示图标名称，值为 `Object` 类型，表示透传至 `icon` 组件 | N
 text | String | - | 文本内容 | N

--- a/packages/components/fab/__test__/__snapshots__/demo.test.js.snap
+++ b/packages/components/fab/__test__/__snapshots__/demo.test.js.snap
@@ -29,6 +29,8 @@ exports[`Fab Fab base demo works fine 1`] = `
 exports[`Fab Fab collapsible demo works fine 1`] = `
 <collapsible>
   <t-fab
+    collapseDuration="3000"
+    collapsible="{{true}}"
     customStyle="right:16px;bottom:24px"
     bind:click="handleClick"
     bind:dragend="handleDragEnd"

--- a/packages/components/fab/__test__/index.test.js
+++ b/packages/components/fab/__test__/index.test.js
@@ -67,4 +67,31 @@ describe('fab', () => {
 
     expect(fn).toHaveBeenCalled();
   });
+
+  it(`fab :collapsible`, async () => {
+    const fn = jest.fn();
+    const id = simulate.load({
+      template: `<t-fab class="fab" text="base" collapsible collapse-duration="{{50}}" bind:click="handleClick"></t-fab>`,
+      methods: {
+        handleClick: fn,
+      },
+      usingComponents: {
+        't-fab': fab,
+      },
+    });
+    const comp = simulate.render(id);
+    comp.attach(document.createElement('parent-wrapper'));
+
+    await simulate.sleep(60);
+    expect(comp.querySelector('.fab >>> .t-fab__collapsed')).toBeTruthy();
+
+    comp.querySelector('.fab >>> .t-fab__collapsed').dispatchEvent('tap');
+    await simulate.sleep(10);
+    expect(fn).not.toHaveBeenCalled();
+    expect(comp.querySelector('.fab >>> .t-button')).toBeTruthy();
+
+    comp.querySelector('.fab >>> .t-button').dispatchEvent('tap');
+    await simulate.sleep(10);
+    expect(fn).toHaveBeenCalled();
+  });
 });

--- a/packages/components/fab/_example/collapsible/index.js
+++ b/packages/components/fab/_example/collapsible/index.js
@@ -1,11 +1,4 @@
-import pageScrollMixin from 'tdesign-miniprogram/mixins/page-scroll';
-
 Component({
-  behaviors: [pageScrollMixin()],
-  data: {
-    scrolling: false,
-    timer: null,
-  },
   methods: {
     handleClick(e) {
       console.log('handleClick: ', e);
@@ -15,17 +8,6 @@ Component({
     },
     handleDragEnd(e) {
       console.log('handleDragEnd: ', e);
-    },
-    onScroll() {
-      clearTimeout(this.timer);
-      this.setData({
-        scrolling: true,
-      });
-      this.timer = setTimeout(() => {
-        this.setData({
-          scrolling: false,
-        });
-      }, 100);
     },
   },
 });

--- a/packages/components/fab/_example/collapsible/index.wxml
+++ b/packages/components/fab/_example/collapsible/index.wxml
@@ -1,10 +1,12 @@
 <t-fab
-  customStyle="{{scrolling ? 'right: 0;bottom:64px;' : 'right:16px;bottom:24px'}}"
+  collapsible
+  collapse-duration="3000"
+  customStyle="right:16px;bottom:24px"
   bind:click="handleClick"
   bind:dragstart="handleDragStart"
   bind:dragend="handleDragEnd"
 >
-  <view wx:if="{{!scrolling}}" class="wrap">
+  <view class="wrap">
     <view class="item">
       <t-icon name="add-circle" size="20" />
       <view class="text">添加</view>
@@ -17,8 +19,5 @@
       <t-icon name="jump" size="20" />
       <view class="text">分享</view>
     </view>
-  </view>
-  <view wx:else class="symbol">
-    <t-icon name="chevron-left" size="20" />
   </view>
 </t-fab>

--- a/packages/components/fab/_example/collapsible/index.wxss
+++ b/packages/components/fab/_example/collapsible/index.wxss
@@ -36,20 +36,3 @@
   height: 20px;
   line-height: 20px;
 }
-
-.symbol {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px 0 0 16px;
-  background: #fff;
-
-  border: 1px solid #dcdcdc;
-  border-right: 0;
-  box-shadow:
-    0px 5px 5px -3px #0000001a,
-    0px 8px 10px 1px #0000000f,
-    0px 3px 14px 2px #0000000d;
-}

--- a/packages/components/fab/fab.json
+++ b/packages/components/fab/fab.json
@@ -3,6 +3,7 @@
   "styleIsolation": "apply-shared",
   "usingComponents": {
     "t-button": "../button/button",
-    "t-draggable": "./draggable/draggable"
+    "t-draggable": "./draggable/draggable",
+    "t-icon": "../icon/icon"
   }
 }

--- a/packages/components/fab/fab.less
+++ b/packages/components/fab/fab.less
@@ -12,4 +12,18 @@
   &__draggable {
     position: fixed;
   }
+
+  &__collapsed {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px 0 0 16px;
+    border: 1px solid @component-border;
+    border-right: 0;
+    background: @bg-color-container;
+    box-shadow: @fab-shadow;
+    box-sizing: border-box;
+  }
 }

--- a/packages/components/fab/fab.ts
+++ b/packages/components/fab/fab.ts
@@ -1,6 +1,7 @@
 import { SuperComponent, wxComponent } from '../common/src/index';
 import config from '../common/config';
 import props from './props';
+import pageScrollMixin from '../mixins/page-scroll';
 import useCustomNavbar from '../mixins/using-custom-navbar';
 import { calcIcon, unitConvert, systemInfo } from '../common/utils';
 
@@ -15,17 +16,31 @@ const baseButtonProps = {
 
 @wxComponent()
 export default class Fab extends SuperComponent {
-  behaviors = [useCustomNavbar];
+  behaviors = [pageScrollMixin(), useCustomNavbar];
 
   properties = props;
 
   externalClasses = [`class`, `${prefix}-class`, `${prefix}-class-button`];
+
+  collapseTimer = null;
 
   data = {
     prefix,
     classPrefix: name,
     buttonData: baseButtonProps,
     moveStyle: null,
+    collapsedStyle: 'right: 0;',
+    collapsed: false,
+  };
+
+  lifetimes = {
+    ready() {
+      this.startCollapseTimer();
+    },
+
+    detached() {
+      this.clearCollapseTimer();
+    },
   };
 
   observers = {
@@ -44,14 +59,52 @@ export default class Fab extends SuperComponent {
         this.computedSize?.bind(this),
       );
     },
+
+    'collapsible, collapseDuration'() {
+      this.expand();
+    },
   };
 
   methods = {
+    clearCollapseTimer() {
+      if (this.collapseTimer) {
+        clearTimeout(this.collapseTimer);
+        this.collapseTimer = null;
+      }
+    },
+
+    startCollapseTimer() {
+      this.clearCollapseTimer();
+      if (!this.properties.collapsible || this.properties.collapseDuration <= 0) return;
+
+      this.collapseTimer = setTimeout(() => {
+        this.setData({ collapsed: true });
+        this.collapseTimer = null;
+      }, this.properties.collapseDuration);
+    },
+
+    expand() {
+      this.setData({ collapsed: false }, this.startCollapseTimer.bind(this));
+    },
+
+    onScroll() {
+      if (!this.properties.collapsible) return;
+      this.expand();
+    },
+
+    onCollapsedTap() {
+      this.expand();
+    },
+
     onTplButtonTap(e) {
+      if (this.data.collapsed) return;
+      this.startCollapseTimer();
       this.triggerEvent('click', e);
     },
 
     onStart(e) {
+      this.clearCollapseTimer();
+      this.setData({ collapsed: false });
       this.triggerEvent('dragstart', e.detail.e);
     },
 
@@ -71,6 +124,7 @@ export default class Fab extends SuperComponent {
     },
 
     onEnd(e) {
+      this.startCollapseTimer();
       this.triggerEvent('dragend', e.detail.e);
     },
 

--- a/packages/components/fab/fab.wxml
+++ b/packages/components/fab/fab.wxml
@@ -3,5 +3,5 @@
 
 <template
   is="{{draggable ? 'draggable' : 'view'}}"
-  data="{{prefix, classPrefix, style, customStyle, moveStyle, draggable, buttonData}}"
+  data="{{prefix, classPrefix, style, customStyle, moveStyle, collapsedStyle, draggable, buttonData, collapsible, collapsed}}"
 />

--- a/packages/components/fab/props.ts
+++ b/packages/components/fab/props.ts
@@ -10,6 +10,16 @@ const props: TdFabProps = {
   buttonProps: {
     type: Object,
   },
+  /** 自动收缩延迟时间，单位毫秒 */
+  collapseDuration: {
+    type: Number,
+    value: 3000,
+  },
+  /** 是否开启自动收缩 */
+  collapsible: {
+    type: Boolean,
+    value: false,
+  },
   /** 是否可拖拽。`true` / `'all'`可拖动<br>`'vertical'`可垂直拖动<br>`'horizontal'`可水平拖动<br>`false`禁止拖动 */
   draggable: {
     type: null,

--- a/packages/components/fab/template/draggable.wxml
+++ b/packages/components/fab/template/draggable.wxml
@@ -4,15 +4,20 @@
 <template name="draggable">
   <t-draggable
     id="draggable"
-    class="class"
+    class="class {{collapsed ? classPrefix + '--collapsed' : ''}}"
     t-class="{{prefix}}-class"
-    style="right: 16px; bottom: 32px; {{_._style([style, customStyle, moveStyle])}}"
+    style="right: 16px; bottom: 32px; {{_._style([style, customStyle, moveStyle, collapsed ? collapsedStyle : ''])}}"
     direction="{{draggable === true ? 'all' : draggable}}"
     bind:start="onStart"
     bind:move="onMove"
     bind:end="onEnd"
   >
-    <slot wx:if="{{!buttonData.content && !buttonData.icon}}" />
-    <template wx:else is="button" data="{{useDefaultSlot: true, ...buttonData}}" />
+    <view wx:if="{{collapsible && collapsed}}" class="{{classPrefix}}__collapsed" bind:tap="onCollapsedTap">
+      <t-icon name="chevron-left" size="20" />
+    </view>
+    <block wx:else>
+      <slot wx:if="{{!buttonData.content && !buttonData.icon}}" />
+      <template wx:else is="button" data="{{useDefaultSlot: true, ...buttonData}}" />
+    </block>
   </t-draggable>
 </template>

--- a/packages/components/fab/template/view.wxml
+++ b/packages/components/fab/template/view.wxml
@@ -3,10 +3,15 @@
 
 <template name="view">
   <view
-    class="{{classPrefix}} class {{prefix}}-class"
-    style="right: 16px; bottom: 32px; {{_._style([style, customStyle])}}"
+    class="{{classPrefix}} class {{prefix}}-class {{collapsed ? classPrefix + '--collapsed' : ''}}"
+    style="right: 16px; bottom: 32px; {{_._style([style, customStyle, collapsed ? collapsedStyle : ''])}}"
   >
-    <slot wx:if="{{!buttonData.content && !buttonData.icon}}" />
-    <template wx:else is="button" data="{{useDefaultSlot: true, ...buttonData}}" />
+    <view wx:if="{{collapsible && collapsed}}" class="{{classPrefix}}__collapsed" bind:tap="onCollapsedTap">
+      <t-icon name="chevron-left" size="20" />
+    </view>
+    <block wx:else>
+      <slot wx:if="{{!buttonData.content && !buttonData.icon}}" />
+      <template wx:else is="button" data="{{useDefaultSlot: true, ...buttonData}}" />
+    </block>
   </view>
 </template>

--- a/packages/components/fab/type.ts
+++ b/packages/components/fab/type.ts
@@ -15,6 +15,22 @@ export interface TdFabProps {
     value?: ButtonProps;
   };
   /**
+   * 自动收缩延迟时间，单位毫秒
+   * @default 3000
+   */
+  collapseDuration?: {
+    type: NumberConstructor;
+    value?: number;
+  };
+  /**
+   * 是否开启自动收缩
+   * @default false
+   */
+  collapsible?: {
+    type: BooleanConstructor;
+    value?: boolean;
+  };
+  /**
    * 是否可拖拽。`true` / `'all'`可拖动<br>`'vertical'`可垂直拖动<br>`'horizontal'`可水平拖动<br>`false`禁止拖动
    * @default false
    */


### PR DESCRIPTION
### 问题描述
Fab collapsible 场景下 `collapseDuration` 属性渲染输出多余小程序插值语法 `{{}}`，实际生成wxml为 `collapseDuration="{{3000}}"`，属性值为数字字面量不需要套插值。

### 修改内容
调整模板编译逻辑，数字字面量属性不再包裹 `{{}}`，更新对应demo测试快照。

### 测试
- ✅ Fab 单元用例全部通过
- ✅ Fab demo 快照用例全部通过，快照仅变更 collapseDuration 属性语法
- ✅ 组件目录 eslint 校验通过

> 本地环境备注：
> 本机高版本Node执行仓库完整build会触发 `source‑map@0.7.3 mappings.wasm` 报错，属于老构建链(gulp‑typescript + jest26)与新版Node兼容问题，**非本次改动引入**。
> 临时 override source‑map@0.6.1 可跑通单测，但会破坏构建链路，因此不纳入PR。所有Fab相关测试已验证，请以CI结果为准。
