### PR TITLE
fix(back-top): 使用catch:tap阻止tap事件冒泡，增加回归测试

### DIFF
--- a/packages/components/back-top/__test__/index.test.js
+++ b/packages/components/back-top/__test__/index.test.js
@@ -53,4 +53,33 @@ describe('back-top', () => {
     await simulate.sleep(10);
     expect(onToTop).toHaveBeenCalledTimes(1);
   });
+
+  it(`: should not bubble tap event`, async () => {
+    const onToTop = jest.fn();
+    const onWrapperTap = jest.fn();
+    const id = simulate.load({
+      template: `
+        <view bind:tap="onWrapperTap">
+          <t-back-top class="base" bind:to-top="onToTop"></t-back-top>
+        </view>
+      `,
+      methods: {
+        onToTop,
+        onWrapperTap,
+      },
+      usingComponents: {
+        't-back-top': backtop,
+      },
+    });
+
+    const comp = simulate.render(id);
+    comp.attach(document.createElement('parent-wrapper'));
+
+    const $backTop = comp.querySelector('.base >>> .t-back-top');
+    $backTop.dispatchEvent('tap');
+    await simulate.sleep(10);
+
+    expect(onToTop).toHaveBeenCalledTimes(1);
+    expect(onWrapperTap).not.toHaveBeenCalled();
+  });
 });

--- a/packages/components/back-top/back-top.wxml
+++ b/packages/components/back-top/back-top.wxml
@@ -4,7 +4,7 @@
 <view
   style="{{_._style([style, customStyle])}}"
   class="class {{prefix}}-class {{_.cls(classPrefix, [['fixed', fixed], theme])}}"
-  bindtap="toTop"
+  catch:tap="toTop"
   aria-role="button"
   hidden="{{hidden}}"
 >


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- 日常 bug 修复
- 新特性提交
- 文档改进
- 演示代码改进
- 组件样式 / 交互改进
- CI/CD 改进
- 重构
- 代码风格优化
- 测试用例
- 分支合并
- 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

#### 问题背景

目前 `BackTop` 组件根节点点击事件使用 `bindtap` 绑定，**tap 事件会向外冒泡**，当组件嵌套在可点击父容器中时，会触发父级点击逻辑，与 TDesign 其他基础组件（如 Button）的事件阻断行为不一致，存在交互体验 bug。

#### 解决方案

1. 将组件根节点 `bindtap` 改为 `catch:tap`，**阻断 tap 事件冒泡**，统一组件交互规范；
2. 新增单元回归测试用例，覆盖「组件点击不触发父级 tap 冒泡」场景，保证后续迭代不退化。

#### 无 UI、无 API、无样式、无兼容性变更

### 📝 更新日志

- 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram

- fix (back-top): 修复点击事件冒泡问题，统一组件交互规范，补充冒泡阻断回归单测

#### @tdesign/uniapp

无

#### @tdesign/uniapp-chat

无

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- 文档已补充或无须补充
- 代码演示已提供或无须提供
- TypeScript 定义已补充或无须补充
- Changelog 已提供或无须补充

---

### 补充本地环境说明（粘贴在末尾，适配你之前的 PR 风格）

本机高版本 Node 执行完整构建 / 覆盖率收集会触发 `source-map@0.7.3 mappings.wasm` 报错，属于项目老旧构建链（gulp-typescript + jest26）与新版 Node 的兼容问题，**非本次代码改动引入**，所有 BackTop 单元测试已本地全量通过，请以 CI 结果为准。