### PR TITLE
fix(toast): 修正销毁事件名拼写错误 destory → destroy

### DIFF
--- a/packages/components/toast/__test__/index.test.js
+++ b/packages/components/toast/__test__/index.test.js
@@ -34,12 +34,12 @@ describe('toast', () => {
 
   it(':base', async () => {
     const close = jest.fn();
-    const destory = jest.fn();
+    const destroy = jest.fn();
     const id = simulate.load({
-      template: `<t-toast id="toast" bind:close="close" bind:destory="destory"></t-toast>`,
+      template: `<t-toast id="toast" bind:close="close" bind:destroy="destroy"></t-toast>`,
       methods: {
         close,
-        destory,
+        destroy,
       },
       usingComponents: {
         't-toast': toast,
@@ -64,7 +64,7 @@ describe('toast', () => {
 
     await simulate.sleep(0);
 
-    expect(destory).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 
   it(':duration', async () => {

--- a/packages/components/toast/toast.ts
+++ b/packages/components/toast/toast.ts
@@ -93,7 +93,7 @@ export default class Toast extends SuperComponent {
         clearTimeout(this.hideTimer);
         this.hideTimer = null;
       }
-      this.triggerEvent('destory');
+      this.triggerEvent('destroy');
     },
 
     loop() {},


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#1919

### 💡 需求背景和解决方案
#### 问题背景
Toast 组件文档对外暴露事件名为 `destroy`，但组件内部实际触发事件拼写错误为 `destory`。
开发者按照文档监听 `bind:destroy` 将永远收不到销毁回调，只能通过错误的 `bind:destory` 才能拿到事件。

#### 解决方案
1. `toast.ts` 将 `this.triggerEvent('destory')` 修改为正确拼写 `this.triggerEvent('destroy')`
2. 修改单元测试模板与mock变量，同步为正确事件名 `destroy`，补充回归校验。

> ⚠️ Breaking Change提示：
如果业务项目曾经临时监听错误事件名 `bind:destory` 做兼容，升级之后需要修改为标准 `bind:destroy`。

无UI、无样式、无API新增。

### 📝 更新日志
- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram
- fix(toast): 修复销毁事件拼写错误 `destory` → `destroy`，对齐文档定义

#### @tdesign/uniapp
无

#### @tdesign/uniapp-chat
无

### ☑️ 请求合并前的自查清单
⚠️ 请自检并全部**勾选全部选项**。⚠️
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须补充

---
### 本地环境备注
本机高版本 Node 执行完整构建/覆盖率收集会触发 `source‑map@0.7.3 mappings.wasm` 报错，属于项目老旧构建链(gulp‑typescript + jest26)与新版Node兼容问题，**非本次改动引入**，所有Toast单元测试已本地全量通过，请以CI结果为准。
