### PR TITLE
fix(Avatar): fix image load error fallback and reload when image source changes

### DIFF
--- a/packages/components/avatar-group/type.ts
+++ b/packages/components/avatar-group/type.ts
@@ -4,7 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
-import { ShapeEnum } from '../common/common';
+import type { ShapeEnum } from '../common/common';
 
 export interface TdAvatarGroupProps {
   /**

--- a/packages/components/avatar/README.en-US.md
+++ b/packages/components/avatar/README.en-US.md
@@ -9,13 +9,13 @@ name | type | default | description | required
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
 alt | String | - | show it when url is not valid | N
-badge-props | Object | - | Typescript：`BadgeProps`，[Badge API Documents](./badge?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar/type.ts) | N
+badge-props | Object | - | Typescript: `BadgeProps`，[Badge API Documents](./badge?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar/type.ts) | N
 bordered | Boolean | false | \- | N
 hide-on-load-failed | Boolean | false | hide image when loading image failed | N
 icon | String / Object | - | \- | N
 image | String | - | images url | N
-image-props | Object | - | Typescript：`ImageProps`，[Image API Documents](./image?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar/type.ts) | N
-shape | String | - | shape。options: circle/round。Typescript：`ShapeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
+image-props | Object | - | Typescript: `ImageProps`，[Image API Documents](./image?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar/type.ts) | N
+shape | String | - | shape。options: circle/round。Typescript: `ShapeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
 size | String | - | size | N
 
 ### Avatar Events
@@ -47,10 +47,10 @@ name | type | default | description | required
 -- | -- | -- | -- | --
 style | Object | - | CSS(Cascading Style Sheets) | N
 custom-style | Object | - | CSS(Cascading Style Sheets)，used to set style on virtual component | N
-cascading | String | 'left-up' | multiple images cascading。options: left-up/right-up。Typescript：`CascadingValue` `type CascadingValue = 'left-up' \| 'right-up'`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar-group/type.ts) | N
+cascading | String | 'left-up' | multiple images cascading。options: left-up/right-up。Typescript: `CascadingValue` `type CascadingValue = 'left-up' \| 'right-up'`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/avatar-group/type.ts) | N
 collapse-avatar | String | - | \- | N
 max | Number | - | \- | N
-shape | String | - | shape。options: circle/round。Typescript：`ShapeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
+shape | String | - | shape。options: circle/round。Typescript: `ShapeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-miniprogram/blob/develop/packages/components/common/common.ts) | N
 size | String | - | size | N
 
 ### AvatarGroup Events

--- a/packages/components/avatar/__test__/index.test.js
+++ b/packages/components/avatar/__test__/index.test.js
@@ -67,7 +67,18 @@ describe('Avatar & Avatar Groups', () => {
       expect($text.dom.textContent).toBe('A');
     });
 
-    it(':hideOnLoadFailed', async () => {
+    it(':hideOnLoadFailed=false 图片加载失败后保留图片', async () => {
+      const comp = simulate.render(id);
+      comp.attach(document.createElement('parent-wrapper'));
+
+      const $image = comp.querySelector('.error-avatar-wrapper >>> #image');
+      $image.dispatchEvent('error');
+      await simulate.sleep(20);
+      // 默认 hideOnLoadFailed=false：图片组件仍保留，由 t-image 内部展示错误占位
+      expect(comp.querySelector('.error-avatar-wrapper >>> .t-image')).toBeTruthy();
+    });
+
+    it(':hideOnLoadFailed=true 图片加载失败后移除图片回退字符', async () => {
       const comp = simulate.render(id);
       comp.attach(document.createElement('parent-wrapper'));
 
@@ -80,7 +91,9 @@ describe('Avatar & Avatar Groups', () => {
       });
       $image.dispatchEvent('error');
       await simulate.sleep(20);
-      expect($wrapper.dom.style.display).toBe('none');
+      // 仅移除图片组件（回退展示字符内容），头像 wrapper 仍保留
+      expect($wrapper.dom.style.display).toBe('');
+      expect(comp.querySelector('.error-avatar-wrapper >>> .t-image')).toBeFalsy();
     });
   });
 

--- a/packages/components/avatar/avatar.less
+++ b/packages/components/avatar/avatar.less
@@ -72,6 +72,14 @@
   &__image {
     width: 100%;
     height: 100%;
+
+    &-alt {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: @spacer;
+      overflow: hidden;
+    }
   }
 
   &--circle {

--- a/packages/components/avatar/avatar.ts
+++ b/packages/components/avatar/avatar.ts
@@ -26,6 +26,7 @@ export default class Avatar extends SuperComponent {
     prefix,
     classPrefix: name,
     isShow: true,
+    isImgExist: true,
     zIndex: 0,
     windowWidth: systemInfo.windowWidth,
   };
@@ -52,6 +53,15 @@ export default class Avatar extends SuperComponent {
         ...obj,
       });
     },
+
+    image(image) {
+      // 图片地址变化时重置加载失败标记，避免切换后无法重新渲染
+      if (image) {
+        this.setData({
+          isImgExist: true,
+        });
+      }
+    },
   };
 
   methods = {
@@ -62,11 +72,9 @@ export default class Avatar extends SuperComponent {
     },
 
     onLoadError(e: WechatMiniprogram.CustomEvent) {
-      if (this.properties.hideOnLoadFailed) {
-        this.setData({
-          isShow: false,
-        });
-      }
+      this.setData({
+        isImgExist: !this.properties.hideOnLoadFailed,
+      });
       this.triggerEvent('error', e.detail);
     },
   };

--- a/packages/components/avatar/avatar.wxml
+++ b/packages/components/avatar/avatar.wxml
@@ -28,9 +28,9 @@
       aria-hidden="{{ ariaHidden }}"
     >
       <t-image
-        wx:if="{{image}}"
+        wx:if="{{image && isImgExist}}"
         t-class="{{prefix}}-image {{classPrefix}}__image"
-        t-class-load="{{prefix}}-class-alt"
+        t-class-load="{{classPrefix}}__image-alt {{prefix}}-class-alt"
         style="{{imageProps && imageProps.style || ''}}"
         src="{{image}}"
         mode="{{imageProps && imageProps.mode || 'aspectFill'}}"
@@ -38,7 +38,7 @@
         loading="{{imageProps && imageProps.loading || 'default'}}"
         shape="{{imageProps && imageProps.shape || 'round'}}"
         webp="{{imageProps && imageProps.webp || false}}"
-        error="{{alt || 'default'}}"
+        error="{{imageProps && imageProps.error || alt || 'default'}}"
         bind:error="onLoadError"
       />
       <template

--- a/packages/components/avatar/type.ts
+++ b/packages/components/avatar/type.ts
@@ -6,7 +6,7 @@
 
 import { BadgeProps } from '../badge/index';
 import { ImageProps } from '../image/index';
-import { ShapeEnum } from '../common/common';
+import type { ShapeEnum } from '../common/common';
 
 export interface TdAvatarProps {
   /**

--- a/packages/tdesign-miniprogram/.changelog/pr-4635.md
+++ b/packages/tdesign-miniprogram/.changelog/pr-4635.md
@@ -1,0 +1,6 @@
+---
+pr_number: 4635
+contributor: anlyyao
+---
+
+- fix(Avatar): 修复图片加载失败后回退展示及切换图片地址无法重新加载的问题 @anlyyao ([#4635](https://github.com/Tencent/tdesign-miniprogram/pull/4635))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #2468

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

#4570 

方案：hideOnLoadFailed 重新对齐桌面端语义

**【非 breaking change】Avatar 组件行为变更说明:**  hideOnLoadFailed 图片加载失败后的表现变化
> 当 `hideOnLoadFailed=true` 且图片加载失败时，处理逻辑由「隐藏整个头像」调整为「仅移除图片、回退展示占位内容」。

| 维度 | 旧行为 | 新行为 |
| --- | --- | --- |
| 处理方式 | `isShow=false`，隐藏整个头像 wrapper | `isImgExist=false`，仅移除图片节点 |
| 视觉结果 | 头像完全消失（`display:none`） | wrapper 保留，回退展示 `icon` 或字符（`slot`） |
| 对应代码 | `onLoadError` 中 `setData({ isShow: false })` | `onLoadError` 中 `setData({ isImgExist: !hideOnLoadFailed })` |
| 影响 | 回退占位（图标/字符）无法展示 | 符合文档语义「加载失败时隐藏图片」，占位内容可见 |

效果：https://developers.weixin.qq.com/s/srkITZmW80by
> <img width="800"   alt="截屏2026-09-09 16 15 44" src="https://github.com/user-attachments/assets/c2540dd5-f91a-4864-853c-f04f39266244" />


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-miniprogram
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Avatar): 修复图片加载失败后回退展示及切换图片地址无法重新加载的问题



#### @tdesign/uniapp
<!--
- feat(组件名称): 处理问题或特性描述
-->



#### @tdesign/uniapp-chat
<!--
- feat(组件名称): 处理问题或特性描述
-->



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
